### PR TITLE
Update Makefile to support latest version of Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all: check_go_version sif
 check_go_version:
 	@echo "$$COPYRIGHT_ASCII"
 	@echo "🔍 Checking Go version..."
-	@$(GO) version | grep -q "go1\.23\." || (echo "❌ Error: Please install the latest version of Go" && exit 1)
+	@$(GO) version | grep -E "go1\.(23|24|25)\." || (echo "❌ Error: Unsupported Go version. Install Go 1.23 or later." && exit 1)
 	@echo "✅ Go version check passed!"
 
 sif: check_go_version


### PR DESCRIPTION
The PR updates makefile check for Go version to support latest version of Go.

The current makefile only allows Go 1.23, which is not the latest anymore. Further this update allows updates in future to be compatible without any changes