### PR TITLE
chore: bump copyright headers to 2026

### DIFF
--- a/.github/workflows/header-check.yml
+++ b/.github/workflows/header-check.yml
@@ -44,7 +44,7 @@ jobs:
             echo ':   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :'
             echo ':   ▄█ █ █▀    ·   BSD 3-Clause License                                         :'
             echo ':                                                                               :'
-            echo ':   (c) 2022-2025 vmfunc, xyzeva,                                               :'
+            echo ':   (c) 2022-2026 vmfunc, xyzeva,                                               :'
             echo ':                 lunchcat alumni & contributors                                :'
             echo ':                                                                               :'
             echo '·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·'

--- a/cmd/sif/main.go
+++ b/cmd/sif/main.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/modules/loader.go
+++ b/internal/modules/loader.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/modules/registry.go
+++ b/internal/modules/registry.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -16,7 +16,7 @@
 :   SIF   -   Blazing-fast pentesting suite                                :
 :   Blaze    -   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 -------------------------------------------------------------------------------------------------

--- a/internal/nuclei/format/format.go
+++ b/internal/nuclei/format/format.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/nuclei/templates/templates.go
+++ b/internal/nuclei/templates/templates.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/output/progress.go
+++ b/internal/output/progress.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/builtin/frameworks_module.go
+++ b/internal/scan/builtin/frameworks_module.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/builtin/nuclei_module.go
+++ b/internal/scan/builtin/nuclei_module.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/builtin/register.go
+++ b/internal/scan/builtin/register.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/builtin/securitytrails_module.go
+++ b/internal/scan/builtin/securitytrails_module.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/builtin/shodan_module.go
+++ b/internal/scan/builtin/shodan_module.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/builtin/whois_module.go
+++ b/internal/scan/builtin/whois_module.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/cloudstorage.go
+++ b/internal/scan/cloudstorage.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/cms.go
+++ b/internal/scan/cms.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/dirlist.go
+++ b/internal/scan/dirlist.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/dnslist.go
+++ b/internal/scan/dnslist.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/dork.go
+++ b/internal/scan/dork.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/frameworks/cve.go
+++ b/internal/scan/frameworks/cve.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/frameworks/detect.go
+++ b/internal/scan/frameworks/detect.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/frameworks/detect_test.go
+++ b/internal/scan/frameworks/detect_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/frameworks/detector.go
+++ b/internal/scan/frameworks/detector.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -13,7 +13,7 @@
 /*
 
    BSD 3-Clause License
-   (c) 2022-2025 vmfunc, xyzeva & contributors
+   (c) 2022-2026 vmfunc, xyzeva & contributors
 
 */
 

--- a/internal/scan/frameworks/detectors/backend.go
+++ b/internal/scan/frameworks/detectors/backend.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -13,7 +13,7 @@
 /*
 
    BSD 3-Clause License
-   (c) 2022-2025 vmfunc, xyzeva & contributors
+   (c) 2022-2026 vmfunc, xyzeva & contributors
 
 */
 

--- a/internal/scan/frameworks/detectors/cms.go
+++ b/internal/scan/frameworks/detectors/cms.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -13,7 +13,7 @@
 /*
 
    BSD 3-Clause License
-   (c) 2022-2025 vmfunc, xyzeva & contributors
+   (c) 2022-2026 vmfunc, xyzeva & contributors
 
 */
 

--- a/internal/scan/frameworks/detectors/frontend.go
+++ b/internal/scan/frameworks/detectors/frontend.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -13,7 +13,7 @@
 /*
 
    BSD 3-Clause License
-   (c) 2022-2025 vmfunc, xyzeva & contributors
+   (c) 2022-2026 vmfunc, xyzeva & contributors
 
 */
 

--- a/internal/scan/frameworks/detectors/meta.go
+++ b/internal/scan/frameworks/detectors/meta.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -13,7 +13,7 @@
 /*
 
    BSD 3-Clause License
-   (c) 2022-2025 vmfunc, xyzeva & contributors
+   (c) 2022-2026 vmfunc, xyzeva & contributors
 
 */
 

--- a/internal/scan/frameworks/fuzz_test.go
+++ b/internal/scan/frameworks/fuzz_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/frameworks/result.go
+++ b/internal/scan/frameworks/result.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -13,7 +13,7 @@
 /*
 
    BSD 3-Clause License
-   (c) 2022-2025 vmfunc, xyzeva & contributors
+   (c) 2022-2026 vmfunc, xyzeva & contributors
 
 */
 

--- a/internal/scan/frameworks/version.go
+++ b/internal/scan/frameworks/version.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/fuzz_test.go
+++ b/internal/scan/fuzz_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/git.go
+++ b/internal/scan/git.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/headers.go
+++ b/internal/scan/headers.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/js/frameworks/next.go
+++ b/internal/scan/js/frameworks/next.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/js/scan.go
+++ b/internal/scan/js/scan.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/js/supabase.go
+++ b/internal/scan/js/supabase.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/lfi.go
+++ b/internal/scan/lfi.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/lfi_test.go
+++ b/internal/scan/lfi_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/nuclei.go
+++ b/internal/scan/nuclei.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/ports.go
+++ b/internal/scan/ports.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/result.go
+++ b/internal/scan/result.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/securitytrails.go
+++ b/internal/scan/securitytrails.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/shodan.go
+++ b/internal/scan/shodan.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/shodan_test.go
+++ b/internal/scan/shodan_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/sql.go
+++ b/internal/scan/sql.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/sql_test.go
+++ b/internal/scan/sql_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/subdomaintakeover.go
+++ b/internal/scan/subdomaintakeover.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/scan/whois.go
+++ b/internal/scan/whois.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/internal/worker/pool_test.go
+++ b/internal/worker/pool_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·

--- a/sif.go
+++ b/sif.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
@@ -76,7 +76,7 @@ func New(settings *config.Settings) (*App, error) {
 
 	if !settings.ApiMode {
 		fmt.Println(output.Box.Render("   █▀ █ █▀▀\n  ▄█ █ █▀ "))
-		fmt.Println(output.Subheading.Render("\nblazing-fast pentesting suite\n\nbsd 3-clause · (c) 2022-2025 vmfunc, xyzeva & contributors\n"))
+		fmt.Println(output.Subheading.Render("\nblazing-fast pentesting suite\n\nbsd 3-clause · (c) 2022-2026 vmfunc, xyzeva & contributors\n"))
 	} else {
 		output.SetAPIMode(true)
 	}

--- a/sif_test.go
+++ b/sif_test.go
@@ -4,7 +4,7 @@
 :   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
 :   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
 :                                                                               :
-:   (c) 2022-2025 vmfunc, xyzeva,                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
 :                 lunchcat alumni & contributors                                :
 :                                                                               :
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·


### PR DESCRIPTION
rolls the `(c) 2022-2025` banner to `2022-2026` everywhere - all go files, the startup banner in sif.go, and the header-check workflow's expected format. comment-only, build/lint/test unaffected.