### PR TITLE
feat: ship a man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ RM ?= rm
 GOFLAGS ?=
 PREFIX ?= /usr/local
 BINDIR ?= bin
+MANDIR ?= share/man/man1
 
 define COPYRIGHT_ASCII
 ╭────────────────────────────────────────────────────────────╮
@@ -76,6 +77,9 @@ install: check_go_version
 	fi
 	@mkdir -p $(DESTDIR)$(PREFIX)/$(BINDIR) || (echo "🔒 Permission denied. Trying with sudo..." && sudo mkdir -p $(DESTDIR)$(PREFIX)/$(BINDIR))
 	@cp -f sif $(DESTDIR)$(PREFIX)/$(BINDIR) || (echo "🔒 Permission denied. Trying with sudo..." && sudo cp -f sif $(DESTDIR)$(PREFIX)/$(BINDIR))
+	@echo "📖 Installing man page..."
+	@mkdir -p $(DESTDIR)$(PREFIX)/$(MANDIR) || (echo "🔒 Permission denied. Trying with sudo..." && sudo mkdir -p $(DESTDIR)$(PREFIX)/$(MANDIR))
+	@cp -f man/sif.1 $(DESTDIR)$(PREFIX)/$(MANDIR) || (echo "🔒 Permission denied. Trying with sudo..." && sudo cp -f man/sif.1 $(DESTDIR)$(PREFIX)/$(MANDIR))
 	@echo "✅ sif installed successfully! 🎊"
 
 uninstall:
@@ -86,6 +90,7 @@ uninstall:
 		exit 1; \
 	fi
 	@$(RM) $(DESTDIR)$(PREFIX)/$(BINDIR)/sif || (echo "🔒 Permission denied. Trying with sudo..." && sudo $(RM) $(DESTDIR)$(PREFIX)/$(BINDIR)/sif)
+	@$(RM) $(DESTDIR)$(PREFIX)/$(MANDIR)/sif.1 || (echo "🔒 Permission denied. Trying with sudo..." && sudo $(RM) $(DESTDIR)$(PREFIX)/$(MANDIR)/sif.1)
 	@echo "✅ sif uninstalled successfully!"
 
 .PHONY: all check_go_version sif clean install uninstall

--- a/man/sif.1
+++ b/man/sif.1
@@ -1,0 +1,164 @@
+.\" man page for sif - the blazing-fast pentesting suite
+.TH sif 1 "2026-06-08" "sif" "sif manual"
+.SH NAME
+sif \- blazing-fast pentesting suite
+.SH SYNOPSIS
+.B sif
+.B \-u
+.I url
+.RI [ scans ]
+.RI [ options ]
+.br
+.B sif
+.B \-f
+.I file
+.RI [ scans ]
+.RI [ options ]
+.br
+.B sif
+.RB { patchnote | version }
+.SH DESCRIPTION
+.B sif
+is a modular recon and exploitation suite. it runs multiple scan types
+concurrently against one or more targets, and can be extended with yaml
+modules. targets must include a
+.B http://
+or
+.B https://
+scheme.
+.SH TARGETS
+.TP
+.BR \-u ", " \-\-urls " \fIlist\fR"
+comma\-separated list of urls to scan.
+.TP
+.BR \-f ", " \-\-file " \fIpath\fR"
+file with one url per line.
+.SH SCANS
+.TP
+.BR \-dirlist " \fIsize\fR"
+directory and file fuzzing (small/medium/large).
+.TP
+.BR \-dnslist " \fIsize\fR"
+subdomain enumeration (small/medium/large).
+.TP
+.BR \-ports " \fIscope\fR"
+port scanning (common/full).
+.TP
+.B \-nuclei
+vulnerability scanning with nuclei templates.
+.TP
+.B \-dork
+automated google dorking.
+.TP
+.B \-js
+javascript analysis.
+.TP
+.B \-c3
+cloud storage misconfiguration scan.
+.TP
+.B \-headers
+dump the target's response headers.
+.TP
+.BR \-sh ", " \-\-security\-headers
+flag missing or weak security headers and headers that leak server internals.
+.TP
+.B \-st
+subdomain takeover detection (requires \fB\-dnslist\fR).
+.TP
+.B \-cms
+cms detection.
+.TP
+.B \-whois
+whois lookup.
+.TP
+.B \-git
+exposed git repository detection.
+.TP
+.B \-shodan
+shodan host lookup (requires \fBSHODAN_API_KEY\fR).
+.TP
+.B \-securitytrails
+domain discovery and target expansion (requires \fBSECURITYTRAILS_API_KEY\fR).
+.TP
+.B \-sql
+sql reconnaissance (admin panels, error disclosure).
+.TP
+.B \-lfi
+local file inclusion reconnaissance.
+.TP
+.B \-framework
+framework detection with cve lookup.
+.TP
+.B \-noscan
+skip the base url scan (robots.txt, etc).
+.SH OPTIONS
+.TP
+.BR \-d ", " \-\-debug
+enable debug logging.
+.TP
+.BR \-t ", " \-\-timeout " \fIduration\fR"
+per\-request timeout (default 10s).
+.TP
+.BR \-l ", " \-\-log " \fIdir\fR"
+directory to write logs to.
+.TP
+.BR \-\-threads " \fIn\fR"
+number of concurrent workers (default 10).
+.TP
+.BR \-\-template " \fIname\fR"
+sif runtime template to use.
+.TP
+.B \-api
+emit json results and suppress the interactive output.
+.SH MODULES
+.TP
+.BR \-m ", " \-\-modules " \fIids\fR"
+comma\-separated module ids to run.
+.TP
+.BR \-mt ", " \-\-module\-tags " \fItags\fR"
+run modules matching these tags.
+.TP
+.BR \-am ", " \-\-all\-modules
+run all loaded modules.
+.TP
+.BR \-lm ", " \-\-list\-modules
+list available modules and exit.
+.SH COMMANDS
+.TP
+.B sif patchnote
+fetch the latest github release and print its notes. also available as
+.BR \-pn .
+.TP
+.B sif version
+print the sif version and exit.
+.SH ENVIRONMENT
+.TP
+.B SHODAN_API_KEY
+api key used by \fB\-shodan\fR.
+.TP
+.B SECURITYTRAILS_API_KEY
+api key used by \fB\-securitytrails\fR.
+.TP
+.B SIF_NO_PATCHNOTES
+set to any value to suppress the once\-per\-version patch note shown at startup.
+.SH FILES
+.TP
+.I ~/.config/sif/modules/
+user\-defined yaml modules.
+.TP
+.I ~/.config/sif/seen_version
+records the last release whose notes were shown at startup.
+.SH EXAMPLES
+.TP
+run a few scans against a host:
+.B sif \-u https://example.com \-headers \-sh \-cms \-framework
+.TP
+fuzz directories and enumerate subdomains:
+.B sif \-u https://example.com \-dirlist medium \-dnslist medium
+.TP
+scan a list of targets and write logs:
+.B sif \-f targets.txt \-headers \-l ./logs
+.SH SEE ALSO
+project page: https://github.com/vmfunc/sif
+.SH AUTHORS
+vmfunc, xyzeva, and the lunchcat contributors.


### PR DESCRIPTION
## summary
- adds `man/sif.1` covering the target/scan/option/module flags, the `patchnote` + `version` commands, env vars (incl `SIF_NO_PATCHNOTES`), files, and a few examples
- the `install`/`uninstall` make targets now drop it in `$(PREFIX)/share/man/man1` (new `MANDIR` var)

## test plan
- [x] `go build ./...`
- [x] renders cleanly with `man ./man/sif.1` and `mandoc -T lint` (only nit is the intentional lowercase title)

## notes
- documents `-sh` and `patchnote`/`version`, so it pairs with #106 and #107
- draft for now - had to pause; will finish/verify when we pick back up