### PR TITLE
feat: stamp and surface the build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ PREFIX ?= /usr/local
 BINDIR ?= bin
 MANDIR ?= share/man/man1
 
+# stamp local builds with the nearest v* tag (or short sha), matching the
+# release ci. --match keeps the automated-release-* tags out of the version.
+VERSION ?= $(shell git describe --tags --match 'v*' --always --dirty 2>/dev/null | sed 's/^v//')
+GO_LDFLAGS = -X main.version=$(VERSION)
+
 define COPYRIGHT_ASCII
 ╭────────────────────────────────────────────────────────────╮
 │                           _____________                    │
@@ -57,7 +62,7 @@ sif: check_go_version
 	@echo "📁 Current directory: $$(pwd)"
 	@echo "🔧 Go flags: $(GOFLAGS)"
 	@echo "📦 Building package: ./cmd/sif"
-	$(GO) build -v $(GOFLAGS) ./cmd/sif
+	$(GO) build -v $(GOFLAGS) -ldflags "$(GO_LDFLAGS)" ./cmd/sif
 	@echo "📊 Build info:"
 	@$(GO) version -m sif
 	@echo "✅ sif built successfully! 🚀"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ makepkg -si
 
 run `./sif -h` for all options.
 
+## commands
+
+a couple of subcommands run without scanning:
+
+```bash
+# print the version (release builds are stamped; local builds use git describe)
+./sif version
+
+# show the latest release notes (also -pn)
+./sif patchnote
+```
+
+the first time you run a new release, sif prints that release's notes once. set `SIF_NO_PATCHNOTES=1` to turn that off.
+
 ## modules
 
 sif has a modular architecture. modules are defined in yaml and can be extended by users.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -259,6 +259,28 @@ enable api mode for json output:
 
 output is a json object with scan results.
 
+## commands
+
+these run without scanning a target.
+
+### version
+
+print the sif version. release builds are stamped via ldflags, local `make` builds derive it from `git describe`, and `go install`ed builds read it from the module build info:
+
+```bash
+./sif version
+```
+
+### patchnote
+
+show the latest release's notes, fetched from github (also `-pn`):
+
+```bash
+./sif patchnote
+```
+
+the first time you run a new release sif also prints that release's notes once. set `SIF_NO_PATCHNOTES=1` to disable that.
+
 ## examples
 
 ### quick recon

--- a/internal/patchnotes/patchnotes.go
+++ b/internal/patchnotes/patchnotes.go
@@ -98,7 +98,9 @@ func Print(tag string) {
 // then records it so it isn't shown again. best-effort: dev builds, the
 // SIF_NO_PATCHNOTES opt-out, and any network failure stay silent.
 func ShowOnce(version string) {
-	if version == "" || version == "dev" || os.Getenv("SIF_NO_PATCHNOTES") != "" {
+	// only clean release tags (e.g. 2026.6.7) map to a github release; skip dev
+	// and pseudo-versions (a commit/dirty build) so we don't make a doomed call.
+	if version == "" || version == "dev" || strings.ContainsAny(version, "-+") || os.Getenv("SIF_NO_PATCHNOTES") != "" {
 		return
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,67 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+// Package version resolves sif's version from the build.
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Resolve returns the best version available: the build-time ldflag if it was
+// stamped, else the go build info (module tag or vcs revision), else "dev". the
+// leading v is dropped so it matches the bare form the rest of sif uses.
+func Resolve(ldflag string) string {
+	if ldflag != "" && ldflag != "dev" {
+		return normalize(ldflag)
+	}
+	if v := fromBuildInfo(); v != "" {
+		return normalize(v)
+	}
+	return "dev"
+}
+
+func fromBuildInfo() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+
+	// no module tag (a local build) - fall back to the commit it was built from
+	var revision, modified string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value
+		}
+	}
+	if revision == "" {
+		return ""
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	if modified == "true" {
+		revision += "-dirty"
+	}
+	return revision
+}
+
+func normalize(v string) string {
+	return strings.TrimPrefix(v, "v")
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -10,54 +10,34 @@
 ·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
 */
 
-package main
+package version
 
-import (
-	"fmt"
-	"os"
+import "testing"
 
-	"github.com/charmbracelet/log"
-	"github.com/dropalldatabases/sif"
-	"github.com/dropalldatabases/sif/internal/config"
-	"github.com/dropalldatabases/sif/internal/patchnotes"
-	ver "github.com/dropalldatabases/sif/internal/version"
-
-	// Register framework detectors
-	_ "github.com/dropalldatabases/sif/internal/scan/frameworks/detectors"
-)
-
-// version is stamped at release time via -ldflags "-X main.version=...";
-// ver.Resolve falls back to the build info or "dev" for other builds.
-var version = "dev"
-
-func main() {
-	version = ver.Resolve(version)
-	sif.Version = version
-
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "patchnote", "patchnotes", "-pn", "--patchnotes":
-			patchnotes.Print("")
-			return
-		case "version", "-version", "--version":
-			fmt.Printf("sif %s\n", version)
-			return
-		}
+func TestResolveLdflag(t *testing.T) {
+	tests := []struct {
+		name   string
+		ldflag string
+		want   string
+	}{
+		{"tag with v", "v2026.6.7", "2026.6.7"},
+		{"tag without v", "2026.6.7", "2026.6.7"},
+		{"pseudo version", "2026.2.17-57-geb33321", "2026.2.17-57-geb33321"},
 	}
 
-	settings := config.Parse()
-
-	app, err := sif.New(settings)
-	if err != nil {
-		log.Fatal(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Resolve(tt.ldflag); got != tt.want {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.ldflag, got, tt.want)
+			}
+		})
 	}
+}
 
-	if !settings.ApiMode {
-		patchnotes.ShowOnce(version)
-	}
-
-	err = app.Run()
-	if err != nil {
-		log.Fatal(err)
+// with no ldflag, Resolve falls back to build info; in a test binary that's
+// non-deterministic, so just assert it never returns an empty string.
+func TestResolveFallbackNonEmpty(t *testing.T) {
+	if Resolve("dev") == "" {
+		t.Error("Resolve fallback should never be empty")
 	}
 }

--- a/sif.go
+++ b/sif.go
@@ -42,6 +42,9 @@ type App struct {
 	logFiles []string
 }
 
+// Version is set by main to the resolved build version and shown on the banner.
+var Version = "dev"
+
 type UrlResult struct {
 	Url     string `json:"url"`
 	Results []ModuleResult
@@ -76,7 +79,11 @@ func New(settings *config.Settings) (*App, error) {
 
 	if !settings.ApiMode {
 		fmt.Println(output.Box.Render("   █▀ █ █▀▀\n  ▄█ █ █▀ "))
-		fmt.Println(output.Subheading.Render("\nblazing-fast pentesting suite\n\nbsd 3-clause · (c) 2022-2026 vmfunc, xyzeva & contributors\n"))
+		tagline := "blazing-fast pentesting suite"
+		if Version != "dev" {
+			tagline += " · v" + Version
+		}
+		fmt.Println(output.Subheading.Render("\n" + tagline + "\n\nbsd 3-clause · (c) 2022-2026 vmfunc, xyzeva & contributors\n"))
 	} else {
 		output.SetAPIMode(true)
 	}


### PR DESCRIPTION
## summary
- new `internal/version` package: resolves the version from the release `-X main.version` ldflag, else go build info (module tag for `go install @vX`, or the vcs commit for local builds), else `dev`
- the boot banner now shows the version, and `sif version` reports the resolved one (was always `dev` for non-release builds)
- the Makefile stamps `make` builds via `git describe --tags --match v*` so local builds get a real version too (the release ci already stamped its binaries)
- `patchnotes.ShowOnce` now skips dev/pseudo versions, so a local build never makes a doomed `/tags/v<pseudo>` github call on first run
- documented `sif version`, `sif patchnote`, and `SIF_NO_PATCHNOTES` in the readme + docs/usage.md (they shipped in #107 but were never documented)

## test plan
- [x] `go build`/`vet`/`golangci-lint` (0 issues), `go test ./...`
- [x] `make` -> `sif version` prints `2026.2.17-60-g76e8893` (git describe), banner shows `· v...`
- [x] release ldflag path unchanged; `go run`/no-git falls back to `dev`