### PR TITLE
fix(nix): bump flake nixpkgs and refresh vendorHash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             version = "unstable-${self.shortRev or self.dirtyShortRev or "dev"}";
             src = ./.;
 
-            vendorHash = "sha256-ztKXnOjZS/jMxsRjtF0rIZ3lKv4YjMdZd6oQFRuAtR4=";
+            vendorHash = "sha256-fR63/dStMsZon22vancuLWIAvZiEYMLjMwY1kmRDNgM=";
 
             # Tests require network access (httptest)
             doCheck = false;


### PR DESCRIPTION
the flake's pinned nixpkgs shipped go 1.25.5 but go.mod now needs >= 1.25.7, so the flake build failed with `GOTOOLCHAIN=local`. this bumps the lock to a nixpkgs with go 1.26.3 and refreshes the stale vendorHash (deps changed this session - glamour etc). verified locally: `nix build .#default` succeeds, so `nix run github:vmfunc/sif` works again.