### PR TITLE
feat(modules): add joomla cms detection module

### DIFF
--- a/modules/info/cms-joomla.yaml
+++ b/modules/info/cms-joomla.yaml
@@ -1,0 +1,36 @@
+# Joomla CMS Detection Module
+
+id: cms-joomla
+info:
+  name: Joomla Detection
+  author: sif
+  severity: info
+  description: Detects Joomla CMS installations
+  tags: [cms, joomla, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/administrator/"
+
+  matchers:
+    - type: word
+      part: all
+      words:
+        - 'generator" content="Joomla!'
+        - "/media/system/js/core.js"
+        - "/media/jui/"
+        - "joomla-script-options"
+      condition: or
+
+  extractors:
+    - type: regex
+      name: joomla_version
+      part: all
+      regex:
+        - 'Joomla! ([0-9]+(?:\.[0-9]+)*) - Open Source'
+        - 'X-Content-Encoded-By: Joomla! ([0-9]+(?:\.[0-9]+)*)'
+      group: 1


### PR DESCRIPTION
the yaml module set had wordpress and drupal but not joomla, while the legacy
`internal/scan/cms.go` detects all three. the new module fills that gap so `--all-modules`
and `-mt cms` cover joomla too. matches the generator meta (version-independent, joomla 1.5
through 5) plus structural markers `/media/system/js/core.js`, `/media/jui/` and
`joomla-script-options`, on the root and `/administrator/`. verified against live and archived
joomla sites, with no false positives on pages that only mention joomla. version comes from a
versioned generator or a leaked `X-Content-Encoded-By` header.

additive: `cms.go` is untouched, the `-cms` scan is unchanged. whether converted scanners
should also run in the default flow is the open question on #52.

refs #52
