### PR TITLE
fix(nix): refresh vendorHash for current deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             version = "unstable-${self.shortRev or self.dirtyShortRev or "dev"}";
             src = ./.;
 
-            vendorHash = "sha256-fR63/dStMsZon22vancuLWIAvZiEYMLjMwY1kmRDNgM=";
+            vendorHash = "sha256-37CzZAVGRfvpZ7WNEJtSXxhQJSYPk1BL03X9pZGhVQ4=";
 
             # Tests require network access (httptest)
             doCheck = false;


### PR DESCRIPTION
go.sum drifted since the last refresh (`x/net`, `glamour`, `colly` and `murmur3` were bumped),
so the pinned `vendorHash` no longer matched and the flake build failed with a fixed-output
hash mismatch. refresh it for the current deps.

`nix build` and `nix run github:vmfunc/sif` work again.
