### PR TITLE
feat(modules): add ghost, magento and typo3 detection modules

### DIFF
--- a/modules/info/cms-ghost.yaml
+++ b/modules/info/cms-ghost.yaml
@@ -1,0 +1,35 @@
+# Ghost CMS Detection Module
+
+id: cms-ghost
+info:
+  name: Ghost Detection
+  author: sif
+  severity: info
+  description: Detects Ghost publishing platform installations
+  tags: [cms, ghost, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/ghost/"
+
+  matchers:
+    - type: word
+      part: all
+      words:
+        - 'generator" content="Ghost'
+        - "/ghost/api/"
+        - "data-ghost"
+        - "ghost-portal"
+      condition: or
+
+  extractors:
+    - type: regex
+      name: ghost_version
+      part: body
+      regex:
+        - 'generator" content="Ghost ([0-9]+(?:\.[0-9]+)*)'
+      group: 1

--- a/modules/info/cms-magento.yaml
+++ b/modules/info/cms-magento.yaml
@@ -1,0 +1,27 @@
+# Magento CMS Detection Module
+
+id: cms-magento
+info:
+  name: Magento Detection
+  author: sif
+  severity: info
+  description: Detects Magento / Adobe Commerce e-commerce installations
+  tags: [cms, magento, ecommerce, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/customer/account/login/"
+
+  matchers:
+    - type: word
+      part: all
+      words:
+        - "data-mage-init"
+        - "text/x-magento-init"
+        - "mage/cookies"
+        - "Mage.Cookies"
+      condition: or

--- a/modules/info/cms-typo3.yaml
+++ b/modules/info/cms-typo3.yaml
@@ -1,0 +1,27 @@
+# TYPO3 CMS Detection Module
+
+id: cms-typo3
+info:
+  name: TYPO3 Detection
+  author: sif
+  severity: info
+  description: Detects TYPO3 CMS installations
+  tags: [cms, typo3, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/typo3/"
+
+  matchers:
+    - type: word
+      part: all
+      words:
+        - "/typo3conf/"
+        - "/typo3temp/"
+        - "data-namespace-typo3-fluid"
+        - 'generator" content="TYPO3'
+      condition: or


### PR DESCRIPTION
cover three platforms the built-in cms scanner misses (it only handles wordpress, drupal and
joomla). markers are structural (generator meta, framework-specific js init and asset paths),
not bare brand strings, so a page that merely mentions the cms does not match. ghost also
extracts its version from the generator meta.
