### PR TITLE
feat(modules): implement size matcher and kv extractor

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -199,6 +199,18 @@ matchers:
     condition: or
 ```
 
+### size matcher
+
+match the response body length in bytes (measured after the 5 MB response cap, so larger sizes never match).
+
+```yaml
+matchers:
+  - type: size
+    size:
+      - 0
+      - 1337
+```
+
 ### combining matchers
 
 multiple matchers are combined with AND logic by default.
@@ -238,7 +250,7 @@ extractors:
 
 ### kv extractor
 
-extract key-value pairs.
+record every response header as a key-value pair, namespaced by `name`.
 
 ```yaml
 extractors:

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -266,6 +266,15 @@ func checkMatcher(m *Matcher, resp *http.Response, body string) bool {
 	case "regex":
 		return checkRegex(part, m.Regex, m.Condition)
 
+	case "size":
+		// size matches the response body length against any listed value.
+		for _, n := range m.Size {
+			if len(body) == n {
+				return true
+			}
+		}
+		return false
+
 	default:
 		return false
 	}
@@ -356,9 +365,9 @@ func runExtractors(extractors []Extractor, resp *http.Response, body string) map
 	result := make(map[string]string)
 
 	for _, e := range extractors {
-		part := getPart(e.Part, resp, body)
-
-		if e.Type == "regex" {
+		switch e.Type {
+		case "regex":
+			part := getPart(e.Part, resp, body)
 			for _, pattern := range e.Regex {
 				re, err := regexp.Compile(pattern)
 				if err != nil {
@@ -369,6 +378,16 @@ func runExtractors(extractors []Extractor, resp *http.Response, body string) map
 					result[e.Name] = matches[e.Group]
 					break
 				}
+			}
+		case "kv":
+			// kv records response header key/values, namespaced by the extractor
+			// name when set (e.g. a headers module surfacing every header).
+			for k, v := range resp.Header {
+				key := k
+				if e.Name != "" {
+					key = e.Name + "." + k
+				}
+				result[key] = strings.Join(v, ", ")
 			}
 		}
 	}

--- a/internal/modules/executor_test.go
+++ b/internal/modules/executor_test.go
@@ -143,6 +143,79 @@ func TestExecuteHTTPModulePayloadExpansion(t *testing.T) {
 	}
 }
 
+// TestExecuteHTTPModuleSizeMatcher pins the size matcher: it fires when the
+// response body length equals a listed value and stays silent otherwise.
+func TestExecuteHTTPModuleSizeMatcher(t *testing.T) {
+	body := "1234567890" // 10 bytes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+	mod := func(id string, size int) *YAMLModule {
+		return &YAMLModule{
+			ID: id, Type: TypeHTTP,
+			HTTP: &HTTPConfig{
+				Paths:    []string{"{{BaseURL}}/"},
+				Matchers: []Matcher{{Type: "size", Size: []int{size}}},
+			},
+		}
+	}
+
+	hit, err := ExecuteHTTPModule(context.Background(), srv.URL, mod("size-hit", len(body)), opts)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPModule(hit): %v", err)
+	}
+	if len(hit.Findings) != 1 {
+		t.Fatalf("size match: got %d findings, want 1", len(hit.Findings))
+	}
+
+	miss, err := ExecuteHTTPModule(context.Background(), srv.URL, mod("size-miss", len(body)+1), opts)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPModule(miss): %v", err)
+	}
+	if len(miss.Findings) != 0 {
+		t.Fatalf("size mismatch: got %d findings, want 0", len(miss.Findings))
+	}
+}
+
+// TestExecuteHTTPModuleKvExtractor pins the kv extractor: it records response
+// header key/values onto the finding, namespaced by the extractor name.
+func TestExecuteHTTPModuleKvExtractor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "nginx/1.25.3")
+		w.Header().Set("X-Powered-By", "PHP/8.2.0")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	def := &YAMLModule{
+		ID: "kv-mod", Type: TypeHTTP,
+		HTTP: &HTTPConfig{
+			Paths:      []string{"{{BaseURL}}/"},
+			Matchers:   []Matcher{{Type: "status", Status: []int{200}}},
+			Extractors: []Extractor{{Type: "kv", Name: "headers", Part: "header"}},
+		},
+	}
+
+	result, err := ExecuteHTTPModule(context.Background(), srv.URL, def, Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)})
+	if err != nil {
+		t.Fatalf("ExecuteHTTPModule: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(result.Findings))
+	}
+	ex := result.Findings[0].Extracted
+	if ex["headers.Server"] != "nginx/1.25.3" {
+		t.Errorf("kv headers.Server = %q, want nginx/1.25.3", ex["headers.Server"])
+	}
+	if ex["headers.X-Powered-By"] != "PHP/8.2.0" {
+		t.Errorf("kv headers.X-Powered-By = %q, want PHP/8.2.0", ex["headers.X-Powered-By"])
+	}
+}
+
 func TestExecuteHTTPModuleNoConfig(t *testing.T) {
 	def := &YAMLModule{ID: "x", Type: TypeHTTP}
 	if _, err := ExecuteHTTPModule(context.Background(), "http://h", def, Options{}); err == nil {

--- a/internal/modules/matchers_test.go
+++ b/internal/modules/matchers_test.go
@@ -339,9 +339,9 @@ func TestRunExtractors(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name: "non-regex extractor type is ignored",
+			name: "unknown extractor type is ignored",
 			extractors: []Extractor{
-				{Type: "kval", Name: "session", Part: "body", Regex: []string{`"session":"([^"]+)"`}, Group: 1},
+				{Type: "bogus", Name: "session", Part: "body", Regex: []string{`"session":"([^"]+)"`}, Group: 1},
 			},
 			wantNil: true,
 		},

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -91,6 +91,7 @@ type Matcher struct {
 	Regex     []string `yaml:"regex,omitempty"`
 	Words     []string `yaml:"words,omitempty"`
 	Status    []int    `yaml:"status,omitempty"`
+	Size      []int    `yaml:"size,omitempty"`
 	Condition string   `yaml:"condition"` // and, or
 	Negative  bool     `yaml:"negative"`
 }
@@ -98,7 +99,7 @@ type Matcher struct {
 // Extractor defines data extraction from responses.
 // Extractors pull specific data from matched responses for reporting.
 type Extractor struct {
-	Type  string   `yaml:"type"` // regex, kval, json
+	Type  string   `yaml:"type"` // regex, kv, json
 	Name  string   `yaml:"name"`
 	Part  string   `yaml:"part"`
 	Regex []string `yaml:"regex,omitempty"`


### PR DESCRIPTION
the engine declared size matchers and kv extractors but the executor dropped them (`size` fell
through to the default case, `kv` was never read). wire both: `size` matches the response body
length in bytes, `kv` records every response header as a key-value pair namespaced by the
extractor name. this unblocks the `headers.go` conversion in #52, which needs a full header
dump the known-set regex extractors cannot reproduce; the `headers.yaml` module and the
`headers.go` removal are a separate follow-up. the extractor is named `kv` to match
`docs/modules.md` (the struct comment said `kval`). the declared json extractor stays deferred
since it needs a json-path dependency and a path-syntax decision.

build/vet/lint clean, `go test ./internal/modules/` green.

refs #52
