### PR TITLE
feat(modules): add spring boot actuator exposure module

### DIFF
--- a/modules/recon/spring-actuator-exposure.yaml
+++ b/modules/recon/spring-actuator-exposure.yaml
@@ -1,0 +1,44 @@
+# Spring Boot Actuator Exposure Detection Module
+
+id: spring-actuator-exposure
+info:
+  name: Spring Boot Actuator Exposure
+  author: sif
+  severity: high
+  description: Detects exposed Spring Boot Actuator endpoints leaking internals
+  tags: [spring, actuator, exposure, misconfiguration, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/actuator"
+    - "{{BaseURL}}/actuator/env"
+    - "{{BaseURL}}/actuator/health"
+    - "{{BaseURL}}/actuator/metrics"
+    - "{{BaseURL}}/actuator/configprops"
+    - "{{BaseURL}}/env"
+    - "{{BaseURL}}/health"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      condition: or
+      regex:
+        - '"propertySources"\s*:\s*\['
+        - '"_links"(?s).*?"href"\s*:\s*"[^"]*/actuator"'
+        - '"components"\s*:\s*\{(?s).*?"status"\s*:\s*"(UP|DOWN)"'
+        - '"names"\s*:\s*\[(?s).*?"jvm\.'
+
+  extractors:
+    - type: regex
+      name: active_profiles
+      part: body
+      regex:
+        - '"activeProfiles"\s*:\s*\[\s*"([^"]+)"'
+      group: 1


### PR DESCRIPTION
probe `/actuator` and the env, health and metrics endpoints for an exposed actuator, which
leaks environment variables, config and runtime internals. sif already fingerprints spring
boot as a framework but never checks whether its actuator endpoints are left open. the matchers
key on structural shapes rather than bare tokens: the env `propertySources` array, a hal index
whose links resolve under `/actuator`, detailed health components, and jvm metric names. a bare
`{"status":"UP"}` health check, a generic hateoas api and prose mentions do not match. a custom
management base-path and spring boot 1.x root endpoints are not covered.
