### PR TITLE
feat(modules): add phpinfo exposure module

### DIFF
--- a/modules/recon/phpinfo-exposure.yaml
+++ b/modules/recon/phpinfo-exposure.yaml
@@ -1,0 +1,47 @@
+# PHP Info Exposure Detection Module
+
+id: phpinfo-exposure
+info:
+  name: PHP Info Exposure
+  author: sif
+  severity: high
+  description: Detects exposed phpinfo() pages leaking config and environment
+  tags: [php, phpinfo, exposure, misconfiguration, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/phpinfo.php"
+    - "{{BaseURL}}/info.php"
+    - "{{BaseURL}}/php_info.php"
+    - "{{BaseURL}}/test.php"
+    - "{{BaseURL}}/i.php"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      condition: or
+      regex:
+        - '<title>(PHP [0-9][0-9.]* - )?phpinfo\(\)</title>'
+        - 'Zend Scripting Language Engine:<br />Zend Engine v'
+
+    - type: regex
+      part: body
+      condition: or
+      regex:
+        - 'class="e">PHP Version\s*</td><td class="v">'
+        - 'class="e">System\s*</td>'
+
+  extractors:
+    - type: regex
+      name: php_version
+      part: body
+      regex:
+        - 'class="e">PHP Version\s*</td><td class="v">\s*([0-9]+(?:\.[0-9]+)*)'
+      group: 1


### PR DESCRIPTION
probe `phpinfo.php`, `info.php`, `php_info.php`, `test.php` and `i.php` for an exposed
`phpinfo()` page, which leaks the full php config, environment, loaded extensions and
`$_SERVER` (often credentials). a finding requires both a phpinfo header (the version-stamped
title or the zend engine credit) and a config table row (the PHP Version or System cell), so a
page that only quotes one of those in prose does not match. the php version is read from the
config table.
