### PR TITLE
ci(pr-bot): label fork pull requests via pull_request_target

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -1,7 +1,7 @@
 name: pr bot
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 permissions:
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -23,7 +23,6 @@ jobs:
   size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
       - name: label pr size
         uses: actions/github-script@v9
         with:


### PR DESCRIPTION
the `label`, `size` and `ci-summary` jobs run on `pull_request`, whose `GITHUB_TOKEN` is
read-only for prs opened from a fork, so an external contributor's pr never gets its labels,
`size/*` tag or summary comment. in-repo (dependabot) prs still do. run them on
`pull_request_target` so the jobs get a writable token in the base-repo context. this is safe
because no job checks out or runs the pr head code with that token; they only read pr metadata
through the github api. drop the now-unused checkout in the size job to keep that obvious.
`github.ref` is the base branch under `pull_request_target`, so key concurrency on the pr
number to keep cancellation per-pr.
