### PR TITLE
feat(modules): add prometheus metrics exposure module

### DIFF
--- a/modules/recon/prometheus-metrics-exposure.yaml
+++ b/modules/recon/prometheus-metrics-exposure.yaml
@@ -1,0 +1,38 @@
+# Prometheus Metrics Exposure Detection Module
+
+id: prometheus-metrics-exposure
+info:
+  name: Prometheus Metrics Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed Prometheus metrics endpoint leaking internals
+  tags: [prometheus, metrics, exposure, misconfiguration, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/metrics"
+    - "{{BaseURL}}/actuator/prometheus"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      condition: and
+      regex:
+        - '(?m)^# HELP \S+ '
+        - '(?m)^# TYPE \S+ (counter|gauge|histogram|summary|untyped)'
+        - '(?m)^[a-zA-Z_][a-zA-Z0-9_:]*(\{[^}]*\})? -?[0-9]'
+
+  extractors:
+    - type: regex
+      name: go_version
+      part: body
+      regex:
+        - 'go_info\{version="([^"]+)"'
+      group: 1


### PR DESCRIPTION
an exposed `/metrics` endpoint leaks process, runtime and request internals that aid recon.
match the prometheus text exposition format structurally (a `# HELP` line plus a `# TYPE` line
ending in one of the known metric types) so a json `/metrics` or prose that mentions the
format does not trip it. extract the go runtime version from `go_info` when present.
