### PR TITLE
feat(modules): add django debug page exposure module

### DIFF
--- a/modules/recon/django-debug-exposure.yaml
+++ b/modules/recon/django-debug-exposure.yaml
@@ -1,0 +1,39 @@
+# Django Debug Page Exposure Detection Module
+
+id: django-debug-exposure
+info:
+  name: Django Debug Page Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Django DEBUG=True page leaking internals
+  tags: [django, debug, exposure, misconfiguration, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/sif-probe-nonexistent"
+
+  matchers:
+    - type: status
+      status:
+        - 400
+        - 403
+        - 404
+        - 500
+
+    - type: regex
+      part: body
+      regex:
+        - 'seeing this error because you have <code>DEBUG = True</code>'
+        - '(Request Method:|Django Version:|Using the URLconf defined in)'
+      condition: and
+
+  extractors:
+    - type: regex
+      name: django_version
+      part: body
+      regex:
+        - 'Django Version:[^0-9]{0,30}([0-9]+(?:\.[0-9]+)+)'
+      group: 1


### PR DESCRIPTION
a django app left on `DEBUG=True` renders a technical 404 or 500 page that leaks settings, the
url config, the traceback and request details. a non-existent path triggers the 404 page on
such apps; match the `seeing this error because you have DEBUG = True` footer together with the
page chrome so a normal 404 does not match, then extract the django version.
