### PR TITLE
feat(modules): add werkzeug debugger exposure module

### DIFF
--- a/modules/recon/werkzeug-debugger-exposure.yaml
+++ b/modules/recon/werkzeug-debugger-exposure.yaml
@@ -1,0 +1,36 @@
+# Werkzeug Debugger Exposure Detection Module
+
+id: werkzeug-debugger-exposure
+info:
+  name: Werkzeug Debugger Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Flask/Werkzeug interactive debugger
+  tags: [werkzeug, flask, debug, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/?__debugger__=yes&cmd=resource&f=debugger.js"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - 'if \(CONSOLE_MODE && EVALEX\) \{'
+        - 'EVALEX_TRUSTED'
+      condition: and
+
+  extractors:
+    - type: regex
+      name: werkzeug_version
+      part: header
+      regex:
+        - 'Werkzeug/([0-9]+(?:\.[0-9]+)+)'
+      group: 1


### PR DESCRIPTION
a flask app left on `debug=True` wraps the wsgi app in werkzeug's `DebuggedApplication`, which
serves its debugger assets unauthenticated: `GET /?__debugger__=yes&cmd=resource&f=debugger.js`
returns the debugger javascript with no pin and no live exception required, exposing the
interactive console (an rce vector) and tracebacks that leak source and config. probe that
asset path and match two javascript anchors stable across werkzeug 0.14 through 3.0 so a page
that only references the debugger does not match, then read the werkzeug version from the
server header.
