### PR TITLE
feat(modules): add elasticsearch exposure module

### DIFF
--- a/modules/recon/elasticsearch-exposure.yaml
+++ b/modules/recon/elasticsearch-exposure.yaml
@@ -1,0 +1,36 @@
+# Elasticsearch Exposure Detection Module
+
+id: elasticsearch-exposure
+info:
+  name: Elasticsearch Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed unauthenticated Elasticsearch HTTP API
+  tags: [elasticsearch, datastore, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - '"tagline"\s*:\s*"You Know, for Search"'
+        - '"lucene_version"\s*:\s*"[0-9]'
+      condition: and
+
+  extractors:
+    - type: regex
+      name: elasticsearch_version
+      part: body
+      regex:
+        - '"number"\s*:\s*"([0-9]+(?:\.[0-9]+)+)'
+      group: 1


### PR DESCRIPTION
an elasticsearch node left without authentication answers its root banner to any client, and
versions before 8.0 ship with no auth by default, so a 200 at `/` means every index is
readable without credentials. match the `You Know, for Search` tagline together with the
`lucene_version` field so a page that only quotes the tagline in prose does not match, then
read the cluster version from the `version.number` field.
