### PR TITLE
feat(modules): add couchdb exposure module

### DIFF
--- a/modules/recon/couchdb-exposure.yaml
+++ b/modules/recon/couchdb-exposure.yaml
@@ -1,0 +1,34 @@
+# CouchDB Exposure Detection Module
+
+id: couchdb-exposure
+info:
+  name: CouchDB Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed unauthenticated CouchDB database list
+  tags: [couchdb, datastore, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/_all_dbs"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - '^\s*\['
+
+    - type: regex
+      part: body
+      regex:
+        - '"_users"'
+        - '"_replicator"'
+        - '"_global_changes"'
+      condition: or


### PR DESCRIPTION
probe `/_all_dbs` instead of the `/` welcome banner: couchdb serves the banner publicly even
on a secured 3.x, so a 200 there only proves an instance is reachable. `/_all_dbs` is
admin-gated by default since 3.0 (`admin_only_all_dbs`), so a 200 listing means the database
names are readable without auth on every version, while a secured server returns 401. the
match requires a json array carrying a system database (`_users`, `_replicator` or
`_global_changes`), which keeps non-couchdb arrays and prose clean. no version is extracted
(the `/_all_dbs` array carries none); instances with renamed or deleted system databases are
not matched.
