### PR TITLE
feat(config): add scan templates via -template

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,12 @@ enable verbose logging:
 ./sif -u https://example.com -d
 ```
 
+### templates
+
+`-template` loads a batch of scan settings from a built-in preset or a local yaml file, so a run does not have to pass every flag. see the [usage guide](usage.md) for the presets and file format. command-line flags still take precedence over the template.
+
+sif also reads an ambient config at `~/.config/sif/config.yaml` (created on first run) keyed by the same flag names. passing `-template` uses that template as the config for the run instead of the ambient file.
+
 ## user modules
 
 place custom modules in:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -378,6 +378,33 @@ enable debug logging:
 ./sif -u https://example.com -d
 ```
 
+### --template
+
+load a batch of scan settings from a template instead of passing each flag. the value is either a built-in preset or a local yaml file keyed by flag long-names:
+
+```bash
+./sif -u https://example.com --template recon
+./sif -u https://example.com --template ./my-scans.yaml
+```
+
+built-in presets:
+
+- `minimal`: liveness and fingerprint only (probe, headers, favicon)
+- `recon`: broad non-intrusive discovery, no attack payloads
+- `full`: every scan except the api-key ones (shodan, securitytrails), including the intrusive probes (xss, sql, lfi, redirect)
+
+`full` sends attack payloads, so only run it against targets you are authorized to test.
+
+a local template lists flag long-names, for example:
+
+```yaml
+cms: true
+dirlist: medium
+threads: 20
+```
+
+flags passed on the command line take precedence over the template, so `--template recon -xss` runs the recon preset with an added xss probe.
+
 ## http options
 
 these apply to every outbound request across all scanners (proxy, custom headers, cookie and rate limiting share one client). a scanner that sets a header explicitly still wins over the global default.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@
 package config
 
 import (
+	"os"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -169,7 +170,7 @@ func registerFlags(settings *Settings) *goflags.FlagSet {
 		flagSet.DurationVarP(&settings.Timeout, "timeout", "t", 10*time.Second, "HTTP request timeout"),
 		flagSet.StringVarP(&settings.LogDir, "log", "l", "", "Directory to store logs in"),
 		flagSet.IntVar(&settings.Threads, "threads", 10, "Number of threads to run scans on"),
-		flagSet.StringVar(&settings.Template, "template", "", "Sif runtime template to use"),
+		flagSet.StringVar(&settings.Template, "template", "", "Load scan settings from a template (preset minimal/recon/full, or a local yaml file)"),
 	)
 
 	flagSet.CreateGroup("http", "HTTP",
@@ -211,8 +212,25 @@ func Parse() *Settings {
 	settings := &Settings{}
 	flagSet := registerFlags(settings)
 
-	if err := flagSet.Parse(); err != nil {
-		log.Fatalf("Could not parse flags: %s", err)
+	// -template presets a batch of scans from a yaml file or named preset; point
+	// goflags at it before Parse so it merges as config (cli flags still win) and
+	// replaces the ambient config for this run.
+	templatePath, cleanup, err := templateConfigPath(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Could not load template: %s", err)
+	}
+	if templatePath != "" {
+		flagSet.SetConfigFilePath(templatePath)
+	}
+
+	// Parse merges the template config synchronously, so a temp preset file can
+	// be removed right after, before any fatal exit (no leaking defer).
+	parseErr := flagSet.Parse()
+	if cleanup != nil {
+		cleanup()
+	}
+	if parseErr != nil {
+		log.Fatalf("Could not parse flags: %s", parseErr)
 	}
 
 	// threads feeds wg.Add directly; floor it so 0 isn't a silent no-op and a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,9 +110,9 @@ const (
 	Full
 )
 
-func Parse() *Settings {
-	settings := &Settings{}
-
+// registerFlags builds the flag set for the given settings without parsing it,
+// so callers (Parse and tests) can inspect the registered flags.
+func registerFlags(settings *Settings) *goflags.FlagSet {
 	flagSet := goflags.NewFlagSet()
 	flagSet.SetDescription("a blazing-fast pentesting (recon/exploitation) suite")
 
@@ -203,6 +203,13 @@ func Parse() *Settings {
 		flagSet.BoolVarP(&settings.AllModules, "all-modules", "am", false, "Run all loaded modules"),
 		flagSet.BoolVarP(&settings.ListModules, "list-modules", "lm", false, "List available modules and exit"),
 	)
+
+	return flagSet
+}
+
+func Parse() *Settings {
+	settings := &Settings{}
+	flagSet := registerFlags(settings)
 
 	if err := flagSet.Parse(); err != nil {
 		log.Fatalf("Could not parse flags: %s", err)

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -1,0 +1,116 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package config
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"strings"
+)
+
+//go:embed templates/*.yaml
+var embeddedTemplates embed.FS
+
+// presetNames are the templates shipped in the binary, listed in help and
+// error text. each presets a batch of scans without listing every flag.
+var presetNames = []string{"minimal", "recon", "full"}
+
+// templateConfigPath resolves the -template value into a config file path for
+// goflags to merge, plus a cleanup to run after Parse (embedded presets are
+// written to a temp file). it returns "" when -template is unset.
+func templateConfigPath(args []string) (string, func(), error) {
+	value := templateFlagValue(args)
+	if value == "" {
+		return "", nil, nil
+	}
+	return resolveTemplate(value)
+}
+
+// templateFlagValue pulls the -template value out of raw args; the config path
+// has to be known before Parse, so it cannot come from the parsed flag itself.
+func templateFlagValue(args []string) string {
+	for i, arg := range args {
+		if arg == "-template" || arg == "--template" {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+		if v, ok := strings.CutPrefix(arg, "-template="); ok {
+			return v
+		}
+		if v, ok := strings.CutPrefix(arg, "--template="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// resolveTemplate turns the -template value into a config file path. an existing
+// local file wins; a named preset is materialized from the embedded set; a
+// path-shaped miss or an unknown name is a hard error.
+func resolveTemplate(value string) (string, func(), error) {
+	info, err := os.Stat(value) //nolint:gosec // G304: user-supplied local template path, by design (same as the -f/-w wordlist paths)
+	switch {
+	case err == nil && info.IsDir():
+		return "", nil, fmt.Errorf("template path %q is a directory", value)
+	case err == nil:
+		return value, nil, nil
+	}
+	if data, ok := embeddedPreset(value); ok {
+		return materializePreset(data)
+	}
+	if looksLikePath(value) {
+		return "", nil, fmt.Errorf("template file %q not found", value)
+	}
+	return "", nil, fmt.Errorf("unknown template %q; use a local yaml file or one of: %s",
+		value, strings.Join(presetNames, ", "))
+}
+
+// embeddedPreset returns the bytes of a named preset shipped in the binary.
+func embeddedPreset(name string) ([]byte, bool) {
+	data, err := embeddedTemplates.ReadFile("templates/" + name + ".yaml")
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// materializePreset writes preset bytes to a temp file so goflags, which merges
+// a config by path, can read it; the cleanup removes the file after Parse.
+func materializePreset(data []byte) (string, func(), error) {
+	file, err := os.CreateTemp("", "sif-template-*.yaml")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.Remove(file.Name()) }
+	if _, err := file.Write(data); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return file.Name(), cleanup, nil
+}
+
+// looksLikePath reports whether the value addresses a file rather than a named
+// preset: a path separator or a yaml suffix marks a file.
+func looksLikePath(value string) bool {
+	if strings.ContainsAny(value, `/\`) {
+		return true
+	}
+	return strings.HasSuffix(value, ".yaml") || strings.HasSuffix(value, ".yml")
+}

--- a/internal/config/template_test.go
+++ b/internal/config/template_test.go
@@ -1,0 +1,211 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package config
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/projectdiscovery/goflags"
+	"gopkg.in/yaml.v3"
+)
+
+// writeTemplate drops a yaml template in a temp dir and returns its path.
+func writeTemplate(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tmpl.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write template: %s", err)
+	}
+	return path
+}
+
+// loadPreset registers the real flags, merges the named embedded preset, and
+// returns the resulting settings (no cli scan flags set).
+func loadPreset(t *testing.T, name string) *Settings {
+	t.Helper()
+	goflags.DisableAutoConfigMigration = true
+	path, cleanup, err := resolveTemplate(name)
+	if err != nil {
+		t.Fatalf("resolve %s: %s", name, err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	settings := &Settings{}
+	flagSet := registerFlags(settings)
+	flagSet.SetConfigFilePath(path)
+	if err := flagSet.Parse("-silent"); err != nil {
+		t.Fatalf("parse %s: %s", name, err)
+	}
+	return settings
+}
+
+// every key in an embedded preset must be a real flag long-name. goflags drops
+// unknown config keys silently, so a typo would otherwise ship as a dead no-op.
+func TestPresetKeysAreRegisteredFlags(t *testing.T) {
+	valid := map[string]bool{}
+	registerFlags(&Settings{}).CommandLine.VisitAll(func(f *flag.Flag) {
+		valid[f.Name] = true
+	})
+
+	for _, name := range presetNames {
+		data, ok := embeddedPreset(name)
+		if !ok {
+			t.Errorf("preset %q is not embedded", name)
+			continue
+		}
+		var keys map[string]any
+		if err := yaml.Unmarshal(data, &keys); err != nil {
+			t.Errorf("preset %q is not valid yaml: %s", name, err)
+			continue
+		}
+		for key := range keys {
+			if !valid[key] {
+				t.Errorf("preset %q references unknown flag %q", name, key)
+			}
+		}
+	}
+}
+
+func TestPresetMinimal(t *testing.T) {
+	s := loadPreset(t, "minimal")
+	if !s.Probe || !s.Headers || !s.Favicon {
+		t.Errorf("minimal should enable probe/headers/favicon, got probe=%v headers=%v favicon=%v",
+			s.Probe, s.Headers, s.Favicon)
+	}
+	if s.XSS || s.SQL || s.Nuclei {
+		t.Error("minimal should not enable heavy or intrusive scans")
+	}
+}
+
+func TestPresetReconIsNonIntrusive(t *testing.T) {
+	s := loadPreset(t, "recon")
+	if !s.Passive || !s.Whois || !s.CMS || !s.Probe {
+		t.Errorf("recon should enable passive/whois/cms/probe, got %v/%v/%v/%v",
+			s.Passive, s.Whois, s.CMS, s.Probe)
+	}
+	if s.XSS || s.SQL || s.LFI || s.Redirect {
+		t.Errorf("recon must not enable payload-injecting scans: xss=%v sql=%v lfi=%v redirect=%v",
+			s.XSS, s.SQL, s.LFI, s.Redirect)
+	}
+}
+
+func TestPresetFull(t *testing.T) {
+	s := loadPreset(t, "full")
+	if !s.XSS || !s.SQL || !s.LFI || !s.Redirect {
+		t.Error("full should enable the intrusive scans")
+	}
+	if s.Dirlist != "large" || s.Ports != "full" {
+		t.Errorf("full should set dirlist=large ports=full, got dirlist=%q ports=%q",
+			s.Dirlist, s.Ports)
+	}
+}
+
+// the template merges as the goflags config: it fills flags left at their
+// default, an explicit cli flag still wins, and an untouched flag stays put.
+func TestTemplateConfigPrecedence(t *testing.T) {
+	goflags.DisableAutoConfigMigration = true
+	tmpl := writeTemplate(t, "cms: true\nthreads: 99\n")
+
+	var cms, sql bool
+	var threads int
+	flagSet := goflags.NewFlagSet()
+	flagSet.BoolVar(&cms, "cms", false, "")
+	flagSet.BoolVar(&sql, "sql", false, "")
+	flagSet.IntVar(&threads, "threads", 10, "")
+
+	flagSet.SetConfigFilePath(tmpl)
+	if err := flagSet.Parse("-threads", "5"); err != nil {
+		t.Fatalf("parse: %s", err)
+	}
+
+	if !cms {
+		t.Error("expected template to set cms=true")
+	}
+	if threads != 5 {
+		t.Errorf("expected cli threads 5 to win over template, got %d", threads)
+	}
+	if sql {
+		t.Error("expected sql left untouched to stay false")
+	}
+}
+
+func TestTemplateFlagValue(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"long with space", []string{"-template", "a.yaml"}, "a.yaml"},
+		{"double dash with space", []string{"--template", "b.yaml"}, "b.yaml"},
+		{"long with equals", []string{"-template=c.yaml"}, "c.yaml"},
+		{"double dash with equals", []string{"--template=d.yaml"}, "d.yaml"},
+		{"absent", []string{"-u", "x"}, ""},
+		{"trailing without value", []string{"-u", "x", "-template"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := templateFlagValue(tc.args); got != tc.want {
+				t.Errorf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveTemplateExistingFile(t *testing.T) {
+	path := writeTemplate(t, "cms: true\n")
+	got, cleanup, err := resolveTemplate(path)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("resolveTemplate: %s", err)
+	}
+	if got != path {
+		t.Errorf("expected %q, got %q", path, got)
+	}
+}
+
+func TestResolveTemplateNamedPreset(t *testing.T) {
+	path, cleanup, err := resolveTemplate("recon")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("recon preset should resolve: %s", err)
+	}
+	if path == "" {
+		t.Fatal("expected a materialized preset path")
+	}
+}
+
+func TestResolveTemplateMissingFile(t *testing.T) {
+	if _, _, err := resolveTemplate("./does-not-exist.yaml"); err == nil {
+		t.Fatal("expected an error for a missing template file")
+	}
+}
+
+func TestResolveTemplateDirectory(t *testing.T) {
+	if _, _, err := resolveTemplate(t.TempDir()); err == nil {
+		t.Fatal("expected an error for a directory")
+	}
+}
+
+func TestResolveTemplateUnknownName(t *testing.T) {
+	if _, _, err := resolveTemplate("bogus"); err == nil {
+		t.Fatal("expected an error for an unknown template name")
+	}
+}

--- a/internal/config/templates/full.yaml
+++ b/internal/config/templates/full.yaml
@@ -1,0 +1,28 @@
+# full: thorough and active, including intrusive probes that inject payloads
+# (xss, sql, lfi, redirect). api-key scans (shodan, securitytrails) stay opt-in
+# via their own flags.
+passive: true
+whois: true
+dork: true
+favicon: true
+headers: true
+security-headers: true
+cms: true
+framework: true
+probe: true
+git: true
+js: true
+nuclei: true
+openapi: true
+cors: true
+jwt: true
+c3: true
+st: true
+crawl: true
+sql: true
+lfi: true
+xss: true
+redirect: true
+dirlist: large
+dnslist: large
+ports: full

--- a/internal/config/templates/minimal.yaml
+++ b/internal/config/templates/minimal.yaml
@@ -1,0 +1,4 @@
+# minimal: fast liveness + fingerprint, a handful of benign GETs per target.
+probe: true
+headers: true
+favicon: true

--- a/internal/config/templates/recon.yaml
+++ b/internal/config/templates/recon.yaml
@@ -1,0 +1,11 @@
+# recon: broad non-intrusive discovery (light traffic, no attack payloads).
+passive: true
+whois: true
+dork: true
+favicon: true
+headers: true
+security-headers: true
+cms: true
+framework: true
+probe: true
+dnslist: small


### PR DESCRIPTION
closes #5. wires up the dead `-template` flag so a run loads a batch of scan settings from a
built-in preset or a local yaml file instead of passing every scan flag by hand.

usage:

    sif -u https://example.com --template recon         # built-in preset
    sif -u https://example.com --template ./scans.yaml  # local file

the presets ship embedded via `go:embed`: `minimal` (fast liveness + fingerprint), `recon`
(broad non-intrusive discovery, no attack payloads) and `full` (thorough and active, including
the intrusive xss/sql/lfi/redirect probes; api-key scans stay opt-in). a local file is yaml
keyed by flag long-names, e.g. `cms: true`. the value resolves to a config path handed to
goflags via `SetConfigFilePath`, so it merges as the config: cli flags still win and the
template only fills flags left unset, for that run.

design notes (happy to change):
- **embedded, not fetched.** the issue said "runtime template", but the presets ship via
  `go:embed` rather than a network fetch, so it works offline and a template can't pull
  sensitive config; can move to sif-runtime if you prefer.
- **yaml, not toml.** goflags is yaml-native and the existing `~/.config/sif` config is yaml,
  so a template reuses goflags' own merge.
- **`-template` is a long flag only**, no short alias.
- **ambient config.** sif already reads its `config.yaml`; `-template` swaps in the chosen
  preset for that run.

known limit: a preset can switch a scan on but not back off (a bool left at its zero value
reads as unset), noted in the usage docs.

build/vet/lint clean, `go test -race ./internal/config/` green (a guard pins that every preset
key is a real flag long-name), plus gofmt, go vet and golangci-lint v2.11.4.
