### PR TITLE
fix(frameworks): make Shopify detection specific

### DIFF
--- a/internal/scan/frameworks/detect_test.go
+++ b/internal/scan/frameworks/detect_test.go
@@ -990,3 +990,56 @@ func TestDetectFramework_EmberFalsePositive(t *testing.T) {
 		t.Errorf("false positive: detected Ember.js (confidence %.2f) on prose with 'remember'", result.Confidence)
 	}
 }
+
+func TestDetectFramework_Shopify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Powered-By", "Shopify")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			<!DOCTYPE html>
+			<html>
+			<head><link rel="stylesheet" href="https://cdn.shopify.com/s/files/1/theme.css"></head>
+			<body>
+				<div id="shopify-section-header" class="shopify-section">Store</div>
+			</body>
+			</html>
+		`))
+	}))
+	defer server.Close()
+
+	result, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if result.Name != "Shopify" {
+		t.Errorf("expected framework 'Shopify', got '%s'", result.Name)
+	}
+}
+
+func TestDetectFramework_ShopifyFalsePositive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			<!DOCTYPE html>
+			<html>
+			<head><title>10 Best Shopify Alternatives in 2026</title></head>
+			<body>
+				<h1>Is Shopify Right For You?</h1>
+				<p>We compare Shopify with other e-commerce platforms.</p>
+			</body>
+			</html>
+		`))
+	}))
+	defer server.Close()
+
+	result, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil && result.Name == "Shopify" {
+		t.Errorf("false positive: article mentioning Shopify detected as Shopify (%.2f)", result.Confidence)
+	}
+}

--- a/internal/scan/frameworks/detectors/cms.go
+++ b/internal/scan/frameworks/detectors/cms.go
@@ -147,7 +147,7 @@ func (d *shopifyDetector) Name() string { return "Shopify" }
 
 func (d *shopifyDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "Shopify", Weight: 0.5},
+		{Pattern: "Shopify", Weight: 0.5, HeaderOnly: true},
 		{Pattern: "cdn.shopify.com", Weight: 0.4},
 		{Pattern: "shopify-section", Weight: 0.4},
 		{Pattern: "myshopify.com", Weight: 0.3},


### PR DESCRIPTION
the shopify detector matched the bare word `shopify` in the response body, so any page that
merely mentions shopify (a listicle, a comparison, a `powered by shopify` writeup) was
fingerprinted as a store. match it in the response header instead: every shopify storefront
sends a `powered-by: shopify` header (and `x-shopify-*` headers) that page prose cannot forge.
the structural body markers (`cdn.shopify.com`, `shopify-section`, `myshopify.com`) are
unchanged.

build/vet/lint clean, `go test ./internal/scan/frameworks/...` green.
