### PR TITLE
fix(frameworks): make CodeIgniter detection specific

### DIFF
--- a/internal/scan/frameworks/detect_test.go
+++ b/internal/scan/frameworks/detect_test.go
@@ -1090,3 +1090,49 @@ func TestDetectFramework_SpringBootFalsePositive(t *testing.T) {
 		t.Errorf("expected no Spring Boot match for prose mentioning it, got %.2f confidence", result.Confidence)
 	}
 }
+
+func TestDetectFramework_CodeIgniter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Set-Cookie", "ci_session=a1b2c3d4e5; path=/; HttpOnly")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`<!DOCTYPE html><html><body><h1>My Shop</h1></body></html>`))
+	}))
+	defer server.Close()
+
+	result, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if result.Name != "CodeIgniter" {
+		t.Errorf("expected framework 'CodeIgniter', got '%s'", result.Name)
+	}
+}
+
+func TestDetectFramework_CodeIgniterFalsePositive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			<!DOCTYPE html>
+			<html>
+			<body>
+				<h1>Best PHP frameworks in 2026</h1>
+				<p>Laravel and codeigniter both ship a router and an ORM.</p>
+				<a href="https://codeigniter.com">codeigniter.com</a>
+				<pre>composer create-project codeigniter4/appstarter</pre>
+			</body>
+			</html>
+		`))
+	}))
+	defer server.Close()
+
+	result, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil && result.Name == "CodeIgniter" {
+		t.Errorf("expected no CodeIgniter match for prose mentioning it, got %.2f confidence", result.Confidence)
+	}
+}

--- a/internal/scan/frameworks/detectors/backend.go
+++ b/internal/scan/frameworks/detectors/backend.go
@@ -468,7 +468,6 @@ func (d *codeigniterDetector) Name() string { return "CodeIgniter" }
 
 func (d *codeigniterDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "codeigniter", Weight: 0.4},
 		{Pattern: "ci_session", Weight: 0.4, HeaderOnly: true},
 	}
 }


### PR DESCRIPTION
the codeigniter detector matched the bare word `codeigniter` in the response body, so any page
that merely mentions the framework (a tutorial, a `best php frameworks` listicle, a link to
`codeigniter.com`) was fingerprinted as running it. drop that substring and key on the
`ci_session` cookie alone, codeigniter's documented default session cookie name, which page
prose cannot forge. this narrows detection (an app that renamed its session cookie is no
longer matched), but `ci_session` is the most specific signal it emits by default.

build/vet/lint clean, `go test ./internal/scan/frameworks/...` green.
