### PR TITLE
fix(frameworks): make Spring Boot detection specific

### DIFF
--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -142,7 +142,7 @@ func TestCheckMatcherFaviconNegative(t *testing.T) {
 	signed := int64(fingerprint.FaviconHash(faviconFixture))
 	matchers := []Matcher{{Type: "favicon", Hash: []int64{signed}, Negative: true}}
 	resp := fakeResponse(t, 200, nil)
-	if checkMatchers(matchers, resp, string(faviconFixture)) {
+	if checkMatchers(matchers, "", resp, string(faviconFixture)) {
 		t.Error("negative favicon matcher should not match its own hash")
 	}
 }

--- a/internal/scan/frameworks/detect_test.go
+++ b/internal/scan/frameworks/detect_test.go
@@ -1043,3 +1043,50 @@ func TestDetectFramework_ShopifyFalsePositive(t *testing.T) {
 		t.Errorf("false positive: article mentioning Shopify detected as Shopify (%.2f)", result.Confidence)
 	}
 }
+
+func TestDetectFramework_SpringBoot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`<html><body><h1>Whitelabel Error Page</h1>` +
+			`<p>This application has no explicit mapping for /error, so you are seeing this as a fallback.</p>` +
+			`<div>There was an unexpected error (type=Internal Server Error, status=500).</div>` +
+			`</body></html>`))
+	}))
+	defer server.Close()
+
+	result, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if result.Name != "Spring Boot" {
+		t.Errorf("expected framework 'Spring Boot', got '%s'", result.Name)
+	}
+}
+
+func TestDetectFramework_SpringBootFalsePositive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			<!DOCTYPE html>
+			<html>
+			<body>
+				<h1>Getting started with spring-boot</h1>
+				<p>Add spring-boot-starter-web to your pom.xml and run the app.</p>
+				<a href="https://spring.io/projects/spring-boot">spring.io</a>
+			</body>
+			</html>
+		`))
+	}))
+	defer server.Close()
+
+	result, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil && result.Name == "Spring Boot" {
+		t.Errorf("expected no Spring Boot match for prose mentioning it, got %.2f confidence", result.Confidence)
+	}
+}

--- a/internal/scan/frameworks/detectors/backend.go
+++ b/internal/scan/frameworks/detectors/backend.go
@@ -251,9 +251,9 @@ func (d *springBootDetector) Name() string { return "Spring Boot" }
 
 func (d *springBootDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "spring-boot", Weight: 0.5},
-		{Pattern: "actuator", Weight: 0.3},
-		{Pattern: "whitelabel", Weight: 0.2},
+		{Pattern: "Whitelabel Error Page", Weight: 0.5},
+		{Pattern: "This application has no explicit mapping for /error", Weight: 0.4},
+		{Pattern: "There was an unexpected error (type=", Weight: 0.3},
 	}
 }
 


### PR DESCRIPTION
the spring boot detector matched the bare word `spring-boot` in the response body, so any page
that merely mentions it (a tutorial, a `spring-boot-starter` maven dep, a link to `spring.io`)
was fingerprinted as running it. worse, its `whitelabel` marker was lowercase and never matched
the real default error page, whose text is capitalized `Whitelabel Error Page` (body matching
is case-sensitive). key on the whitelabel error page instead: the `Whitelabel Error Page`
heading, the `no explicit mapping for /error` fallback line and the `There was an unexpected
error (type=` line, all emitted verbatim by spring boot's default error view. this narrows
detection to apps that surface that page and fixes the broken casing so it is actually detected.

build/vet/lint clean, `go test ./internal/scan/frameworks/...` green.
