### PR TITLE
feat(modules): add wordlist file support to http modules

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -127,6 +127,17 @@ http:
 - `clusterbomb` (default) - every path is tried with every payload
 - `pitchfork` - path and payload are paired by index, stopping at the shorter list
 
+#### wordlist
+
+a local file whose non-empty lines fuzz the `{{word}}` placeholder, one request
+per word. paths without `{{word}}` are still requested as-is.
+
+```yaml
+http:
+  wordlist: /usr/share/wordlists/dirs.txt
+  paths:
+    - "{{BaseURL}}/{{word}}"
+```
 #### headers
 
 custom headers to send.

--- a/internal/modules/attack_modes_test.go
+++ b/internal/modules/attack_modes_test.go
@@ -60,7 +60,11 @@ func TestGenerateHTTPRequestsAttack(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &HTTPConfig{Paths: tt.paths, Payloads: tt.payloads, Attack: tt.attack}
-			got := reqURLs(generateHTTPRequests(target, cfg))
+			reqs, err := generateHTTPRequests(target, cfg)
+			if err != nil {
+				t.Fatalf("generateHTTPRequests: %v", err)
+			}
+			got := reqURLs(reqs)
 			want := append([]string(nil), tt.want...)
 			sort.Strings(want)
 			if !reflect.DeepEqual(got, want) {

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -13,11 +13,13 @@
 package modules
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -71,7 +73,10 @@ func ExecuteHTTPModule(ctx context.Context, target string, def *YAMLModule, opts
 	}
 
 	// Generate requests based on paths and payloads
-	requests := generateHTTPRequests(target, cfg)
+	requests, err := generateHTTPRequests(target, cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	// Determine thread count
 	threads := cfg.Threads
@@ -125,8 +130,13 @@ func ExecuteHTTPModule(ctx context.Context, target string, def *YAMLModule, opts
 }
 
 // generateHTTPRequests creates all requests based on paths and payloads.
-func generateHTTPRequests(target string, cfg *HTTPConfig) []*httpRequest {
+func generateHTTPRequests(target string, cfg *HTTPConfig) ([]*httpRequest, error) {
 	var requests []*httpRequest
+
+	paths, err := resolvePaths(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	// Ensure target has no trailing slash
 	target = strings.TrimSuffix(target, "/")
@@ -138,7 +148,7 @@ func generateHTTPRequests(target string, cfg *HTTPConfig) []*httpRequest {
 
 	// If no payloads, just use paths directly
 	if len(cfg.Payloads) == 0 {
-		for _, path := range cfg.Paths {
+		for _, path := range paths {
 			url := substituteVariables(path, target, "")
 			requests = append(requests, &httpRequest{
 				Method:   method,
@@ -148,29 +158,82 @@ func generateHTTPRequests(target string, cfg *HTTPConfig) []*httpRequest {
 				Original: path,
 			})
 		}
-		return requests
+		return requests, nil
 	}
 
 	// pitchfork pairs path[i] with payload[i] and stops at the shorter list;
 	// clusterbomb (default) crosses every path with every payload.
 	if strings.EqualFold(cfg.Attack, "pitchfork") {
-		n := len(cfg.Paths)
+		n := len(paths)
 		if len(cfg.Payloads) < n {
 			n = len(cfg.Payloads)
 		}
 		for i := 0; i < n; i++ {
-			requests = append(requests, newPayloadRequest(method, target, cfg.Paths[i], cfg.Payloads[i], cfg))
+			requests = append(requests, newPayloadRequest(method, target, paths[i], cfg.Payloads[i], cfg))
 		}
-		return requests
+		return requests, nil
 	}
 
-	for _, path := range cfg.Paths {
+	for _, path := range paths {
 		for _, payload := range cfg.Payloads {
 			requests = append(requests, newPayloadRequest(method, target, path, payload, cfg))
 		}
 	}
 
-	return requests
+	return requests, nil
+}
+
+// resolvePaths expands a wordlist over any {{word}} path templates so one
+// "{{BaseURL}}/{{word}}" path fuzzes the whole list; paths without {{word}}
+// pass through literally. no wordlist leaves cfg.Paths untouched.
+func resolvePaths(cfg *HTTPConfig) ([]string, error) {
+	if cfg.Wordlist == "" {
+		return cfg.Paths, nil
+	}
+
+	words, err := loadWordlist(cfg.Wordlist)
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, path := range cfg.Paths {
+		if !strings.Contains(path, "{{word}}") && !strings.Contains(path, "{{Word}}") {
+			paths = append(paths, path)
+			continue
+		}
+		for _, word := range words {
+			expanded := strings.ReplaceAll(path, "{{word}}", word)
+			expanded = strings.ReplaceAll(expanded, "{{Word}}", word)
+			paths = append(paths, expanded)
+		}
+	}
+
+	return paths, nil
+}
+
+// loadWordlist reads non-empty lines from a local wordlist file, mirroring the
+// dirlist scanner's scanLines so a converted module fuzzes the identical words.
+func loadWordlist(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open wordlist %q: %w", path, err)
+	}
+	defer f.Close()
+
+	var words []string
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		if line := scanner.Text(); line != "" {
+			words = append(words, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read wordlist %q: %w", path, err)
+	}
+
+	return words, nil
 }
 
 // newPayloadRequest builds one request with the path and body templates

--- a/internal/modules/executor_test.go
+++ b/internal/modules/executor_test.go
@@ -17,6 +17,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -320,6 +322,48 @@ func TestWrapperExecuteRoutesByType(t *testing.T) {
 			t.Fatal("expected error for unknown module type")
 		}
 	})
+}
+
+// TestExecuteHTTPModuleWordlist proves a {{word}} path templated against a local
+// wordlist drives one real request per word, and only the path that exists fires.
+func TestExecuteHTTPModuleWordlist(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/admin" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	list := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(list, []byte("login\nadmin\nbackup\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	def := &YAMLModule{
+		ID:   "test-wordlist",
+		Type: TypeHTTP,
+		Info: YAMLModuleInfo{Severity: "low"},
+		HTTP: &HTTPConfig{
+			Method:   "GET",
+			Wordlist: list,
+			Paths:    []string{"{{BaseURL}}/{{word}}"},
+			Matchers: []Matcher{{Type: "status", Status: []int{200}}},
+		},
+	}
+
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+	res, err := ExecuteHTTPModule(context.Background(), srv.URL, def, opts)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1 (only /admin exists)", len(res.Findings))
+	}
+	if got := res.Findings[0].URL; got != srv.URL+"/admin" {
+		t.Errorf("finding url = %q, want %q", got, srv.URL+"/admin")
+	}
 }
 
 func TestTruncateEvidence(t *testing.T) {

--- a/internal/modules/matchers_test.go
+++ b/internal/modules/matchers_test.go
@@ -14,6 +14,8 @@ package modules
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -413,7 +415,10 @@ func TestGenerateHTTPRequests(t *testing.T) {
 			Paths: []string{"{{BaseURL}}/a", "{{BaseURL}}/b"},
 		}
 		// trailing slash on the target must be trimmed before substitution.
-		got := generateHTTPRequests("http://h/", cfg)
+		got, err := generateHTTPRequests("http://h/", cfg)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
 		if len(got) != 2 {
 			t.Fatalf("got %d requests, want 2", len(got))
 		}
@@ -432,7 +437,10 @@ func TestGenerateHTTPRequests(t *testing.T) {
 			Payloads: []string{"1", "2", "3"},
 			Body:     "data={{payload}}",
 		}
-		got := generateHTTPRequests("http://h", cfg)
+		got, err := generateHTTPRequests("http://h", cfg)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
 		if len(got) != 3 {
 			t.Fatalf("got %d requests, want 3", len(got))
 		}
@@ -457,9 +465,67 @@ func TestGenerateHTTPRequests(t *testing.T) {
 			Paths:    []string{"{{BaseURL}}/a", "{{BaseURL}}/b"},
 			Payloads: []string{"x", "y"},
 		}
-		got := generateHTTPRequests("http://h", cfg)
+		got, err := generateHTTPRequests("http://h", cfg)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
 		if len(got) != 4 {
 			t.Fatalf("got %d requests, want 4 (2 paths x 2 payloads)", len(got))
+		}
+	})
+
+	t.Run("wordlist expands {{word}} paths", func(t *testing.T) {
+		list := filepath.Join(t.TempDir(), "words.txt")
+		if err := os.WriteFile(list, []byte("admin\n\nconfig\nbackup\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &HTTPConfig{
+			Paths:    []string{"{{BaseURL}}/{{word}}", "{{BaseURL}}/.git/HEAD"},
+			Wordlist: list,
+		}
+		got, err := generateHTTPRequests("http://h", cfg)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		// 3 words (the blank line is skipped) fuzz the templated path, then the
+		// literal path passes through untouched.
+		want := []string{"http://h/admin", "http://h/config", "http://h/backup", "http://h/.git/HEAD"}
+		if len(got) != len(want) {
+			t.Fatalf("got %d requests, want %d", len(got), len(want))
+		}
+		for i, w := range want {
+			if got[i].URL != w {
+				t.Errorf("req %d url = %q, want %q", i, got[i].URL, w)
+			}
+		}
+	})
+
+	t.Run("wordlist crosses with payloads", func(t *testing.T) {
+		list := filepath.Join(t.TempDir(), "words.txt")
+		if err := os.WriteFile(list, []byte("a\nb\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &HTTPConfig{
+			Paths:    []string{"{{BaseURL}}/{{word}}?q={{payload}}"},
+			Wordlist: list,
+			Payloads: []string{"1", "2", "3"},
+		}
+		got, err := generateHTTPRequests("http://h", cfg)
+		if err != nil {
+			t.Fatalf("generate: %v", err)
+		}
+		if len(got) != 6 {
+			t.Fatalf("got %d requests, want 6 (2 words x 3 payloads)", len(got))
+		}
+	})
+
+	t.Run("missing wordlist errors", func(t *testing.T) {
+		cfg := &HTTPConfig{
+			Paths:    []string{"{{BaseURL}}/{{word}}"},
+			Wordlist: filepath.Join(t.TempDir(), "nope.txt"),
+		}
+		if _, err := generateHTTPRequests("http://h", cfg); err == nil {
+			t.Fatal("want error for missing wordlist, got nil")
 		}
 	})
 }

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -55,6 +55,7 @@ type YAMLModuleInfo struct {
 type HTTPConfig struct {
 	Method            string            `yaml:"method"`
 	Paths             []string          `yaml:"paths"`
+	Wordlist          string            `yaml:"wordlist,omitempty"`
 	Payloads          []string          `yaml:"payloads,omitempty"`
 	Headers           map[string]string `yaml:"headers,omitempty"`
 	Body              string            `yaml:"body,omitempty"`


### PR DESCRIPTION
http modules can only request literal paths, so a directory bruteforce cannot be expressed as
a yaml module. add a `wordlist:` field whose non-empty lines fuzz a `{{word}}` placeholder in
the path templates, one request per word; paths without `{{word}}` are still requested as-is.
the loader mirrors the dirlist scanner's `scanLines` so a converted module fuzzes the
identical word set, but it also checks `scanner.Err()`, which `scanLines` does not: it silently
drops a line past bufio's 64k token cap and every line after it. local-file only by design, so
network and remote-trust stay out of the engine; the module-supplied path is the same
trusted-operator input as the dirlist `-w` flag, covered by the existing G304 exclude. scope is
the local-wordlist primitive, a step toward the #52 dirlist conversion, not the whole of it:
the default remote list, extension expansion and the soft-404/filter-regex matchers remain
follow-ups.

build/vet/lint clean, `go test ./internal/modules/` green.

refs #52
