### PR TITLE
feat(frameworks): add config-defined custom detectors

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,38 @@ info:
   # ...
 ```
 
+## custom signatures
+
+framework detection (`-framework`) also loads user-defined detectors from yaml
+files, so a framework sif does not ship can be detected without rebuilding:
+
+- linux/macos: `~/.config/sif/signatures/`
+- windows: `%LOCALAPPDATA%\sif\signatures\`
+
+each file defines one detector; place them directly in the directory, as
+subdirectories are not scanned. `header: true` matches a response header name or
+value (case-insensitive) instead of the body; the optional `version` block pulls
+a version out of the body.
+
+```yaml
+# ~/.config/sif/signatures/ghost.yaml
+name: Ghost
+signatures:
+  - pattern: 'content="Ghost'
+    weight: 0.6
+  - pattern: 'X-Ghost-Cache'
+    weight: 0.4
+    header: true
+version:
+  regex: 'content="Ghost ([0-9.]+)'
+  group: 1
+```
+
+a detector reports a match once its matched signature weights sum past half, so
+weight your signatures to total about `1.0`. a name matching a built-in detector
+overrides it and inherits that built-in's version patterns and known cves, the
+same as user modules.
+
 ## performance tuning
 
 ### fast scans

--- a/internal/scan/frameworks/custom.go
+++ b/internal/scan/frameworks/custom.go
@@ -1,0 +1,193 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+/*
+
+   BSD 3-Clause License
+   (c) 2022-2026 vmfunc, xyzeva & contributors
+
+*/
+
+package frameworks
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+
+	charmlog "github.com/charmbracelet/log"
+	"github.com/dropalldatabases/sif/internal/output"
+	"gopkg.in/yaml.v3"
+)
+
+// customDetector is a Detector defined in a user yaml file rather than compiled
+// in. it scores with the same weighted signature match as the built-ins and
+// optionally pulls a version out of the body.
+type customDetector struct {
+	BaseDetector
+	versionRe    *regexp.Regexp
+	versionGroup int
+}
+
+// Detect returns the weighted signature confidence and, when a version regex is
+// set and matches, the captured version. confidence is the matched-weight
+// fraction directly (not the built-ins' sigmoid), so it clears 0.5 only past half.
+func (d *customDetector) Detect(body string, headers http.Header) (float32, string) {
+	confidence := d.MatchSignatures(body, headers)
+	if confidence == 0 || d.versionRe == nil {
+		return confidence, ""
+	}
+	matches := d.versionRe.FindStringSubmatch(body)
+	if len(matches) > d.versionGroup {
+		return confidence, matches[d.versionGroup]
+	}
+	return confidence, ""
+}
+
+// signatureSpec / versionSpec / customDetectorSpec mirror the yaml on disk.
+type signatureSpec struct {
+	Pattern string  `yaml:"pattern"`
+	Weight  float32 `yaml:"weight"`
+	Header  bool    `yaml:"header"`
+}
+
+type versionSpec struct {
+	Regex string `yaml:"regex"`
+	Group int    `yaml:"group"`
+}
+
+type customDetectorSpec struct {
+	Name       string          `yaml:"name"`
+	Signatures []signatureSpec `yaml:"signatures"`
+	Version    *versionSpec    `yaml:"version"`
+}
+
+// build validates the parsed spec and turns it into a Detector, so a broken
+// file fails loudly instead of registering a detector that can never match.
+func (spec customDetectorSpec) build() (Detector, error) {
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		return nil, fmt.Errorf("missing name")
+	}
+	if len(spec.Signatures) == 0 {
+		return nil, fmt.Errorf("%q has no signatures", name)
+	}
+
+	sigs := make([]Signature, 0, len(spec.Signatures))
+	for i, s := range spec.Signatures {
+		if s.Pattern == "" {
+			return nil, fmt.Errorf("%q: signature %d has an empty pattern", name, i+1)
+		}
+		if s.Weight <= 0 || math.IsInf(float64(s.Weight), 0) || math.IsNaN(float64(s.Weight)) {
+			return nil, fmt.Errorf("%q: signature %q needs a positive, finite weight", name, s.Pattern)
+		}
+		sigs = append(sigs, Signature{Pattern: s.Pattern, Weight: s.Weight, HeaderOnly: s.Header})
+	}
+
+	d := &customDetector{BaseDetector: NewBaseDetector(name, sigs)}
+	if spec.Version != nil {
+		if spec.Version.Group < 0 {
+			return nil, fmt.Errorf("%q: version group must be >= 0", name)
+		}
+		re, err := regexp.Compile(spec.Version.Regex)
+		if err != nil {
+			return nil, fmt.Errorf("%q: version regex: %w", name, err)
+		}
+		d.versionRe = re
+		d.versionGroup = spec.Version.Group
+	}
+	return d, nil
+}
+
+// parseCustomDetector reads and validates one signature file.
+func parseCustomDetector(path string) (Detector, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	var spec customDetectorSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	return spec.build()
+}
+
+// customSignaturesDir is the per-user directory that holds yaml-defined
+// detectors, alongside the user modules directory.
+func customSignaturesDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "windows" {
+		return filepath.Join(home, "AppData", "Local", "sif", "signatures"), nil
+	}
+	return filepath.Join(home, ".config", "sif", "signatures"), nil
+}
+
+// loadCustomDetectors registers every signature file under the user directory.
+// it is driven once, lazily, from DetectFramework.
+func loadCustomDetectors() {
+	dir, err := customSignaturesDir()
+	if err != nil {
+		return
+	}
+	loadCustomDetectorsFromDir(dir)
+}
+
+// loadCustomDetectorsFromDir registers every signature file in dir and returns
+// how many loaded. a custom detector whose name matches a built-in overrides
+// it, matching the user-module convention.
+func loadCustomDetectorsFromDir(dir string) int {
+	detectors := collectCustomDetectors(dir)
+	for _, d := range detectors {
+		Register(d)
+	}
+	if len(detectors) > 0 {
+		output.Module("FRAMEWORK").Info("Loaded %d custom signatures", len(detectors))
+	}
+	return len(detectors)
+}
+
+// collectCustomDetectors parses (without registering) the .yaml/.yml detectors
+// in dir, so discovery and validation stay pure and testable. a missing dir is
+// fine; an unparseable file warns and is skipped rather than failing the scan.
+func collectCustomDetectors(dir string) []Detector {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var detectors []Detector
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		switch filepath.Ext(e.Name()) {
+		case ".yaml", ".yml":
+		default:
+			continue
+		}
+		d, err := parseCustomDetector(filepath.Join(dir, e.Name()))
+		if err != nil {
+			charmlog.Warnf("custom signature %s: %v", e.Name(), err)
+			continue
+		}
+		detectors = append(detectors, d)
+	}
+	return detectors
+}

--- a/internal/scan/frameworks/custom_internal_test.go
+++ b/internal/scan/frameworks/custom_internal_test.go
@@ -1,0 +1,173 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package frameworks
+
+import (
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCustomDetectorSpecBuild(t *testing.T) {
+	valid := customDetectorSpec{
+		Name:       "Ghost",
+		Signatures: []signatureSpec{{Pattern: `content="Ghost`, Weight: 1.0}},
+	}
+	cases := []struct {
+		name    string
+		spec    customDetectorSpec
+		wantErr bool
+	}{
+		{"valid", valid, false},
+		{"empty name", customDetectorSpec{Signatures: valid.Signatures}, true},
+		{"whitespace name", customDetectorSpec{Name: "  ", Signatures: valid.Signatures}, true},
+		{"no signatures", customDetectorSpec{Name: "X"}, true},
+		{"empty pattern", customDetectorSpec{Name: "X", Signatures: []signatureSpec{{Pattern: "", Weight: 1}}}, true},
+		{"zero weight", customDetectorSpec{Name: "X", Signatures: []signatureSpec{{Pattern: "p", Weight: 0}}}, true},
+		{"negative weight", customDetectorSpec{Name: "X", Signatures: []signatureSpec{{Pattern: "p", Weight: -1}}}, true},
+		{"bad version regex", customDetectorSpec{Name: "X", Signatures: []signatureSpec{{Pattern: "p", Weight: 1}}, Version: &versionSpec{Regex: "("}}, true},
+		{"negative version group", customDetectorSpec{Name: "X", Signatures: valid.Signatures, Version: &versionSpec{Regex: `v([0-9]+)`, Group: -1}}, true},
+		{"nan weight", customDetectorSpec{Name: "X", Signatures: []signatureSpec{{Pattern: "p", Weight: float32(math.NaN())}}}, true},
+		{"inf weight", customDetectorSpec{Name: "X", Signatures: []signatureSpec{{Pattern: "p", Weight: float32(math.Inf(1))}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.spec.build(); (err != nil) != tc.wantErr {
+				t.Fatalf("build() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCustomDetectorDetect(t *testing.T) {
+	// the version regex is independent of the signature patterns so a body that
+	// matches it but no signature still must not surface a version.
+	spec := customDetectorSpec{
+		Name: "Acme",
+		Signatures: []signatureSpec{
+			{Pattern: "AcmeCMS", Weight: 0.6},
+			{Pattern: "X-Acme", Weight: 0.4, Header: true},
+		},
+		Version: &versionSpec{Regex: `ver=([0-9.]+)`, Group: 1},
+	}
+	d, err := spec.build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	withHeader := func() http.Header {
+		h := http.Header{}
+		h.Set("X-Acme", "1")
+		return h
+	}
+
+	t.Run("all signatures match: confidence 1, version extracted", func(t *testing.T) {
+		conf, ver := d.Detect("powered by AcmeCMS ver=4.2.0", withHeader())
+		if conf != 1.0 {
+			t.Errorf("confidence = %v, want 1.0", conf)
+		}
+		if ver != "4.2.0" {
+			t.Errorf("version = %q, want 4.2.0", ver)
+		}
+	})
+
+	t.Run("only body signature matches: linear 0.6", func(t *testing.T) {
+		conf, ver := d.Detect("powered by AcmeCMS", http.Header{})
+		if conf != 0.6 {
+			t.Errorf("confidence = %v, want 0.6 (0.6/1.0 matched fraction)", conf)
+		}
+		if ver != "" {
+			t.Errorf("version = %q, want empty", ver)
+		}
+	})
+
+	t.Run("no signature matches: 0 confidence, no version even when present", func(t *testing.T) {
+		conf, ver := d.Detect("ver=9.9.9 but no marker here", http.Header{})
+		if conf != 0 {
+			t.Errorf("confidence = %v, want 0", conf)
+		}
+		if ver != "" {
+			t.Errorf("version = %q, want empty (not detected, so not extracted)", ver)
+		}
+	})
+}
+
+func TestParseCustomDetectorFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fw.yaml")
+	content := `name: Parsed
+signatures:
+  - pattern: "Marker"
+    weight: 0.5
+  - pattern: "X-Hdr"
+    weight: 0.5
+    header: true
+version:
+  regex: 'Parsed/([0-9.]+)'
+  group: 1
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := parseCustomDetector(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Name() != "Parsed" {
+		t.Errorf("name = %q, want Parsed", d.Name())
+	}
+	if len(d.Signatures()) != 2 {
+		t.Errorf("signatures = %d, want 2", len(d.Signatures()))
+	}
+
+	h := http.Header{}
+	h.Set("X-Hdr", "1")
+	conf, ver := d.Detect("Marker Parsed/3.1", h)
+	if conf != 1.0 {
+		t.Errorf("confidence = %v, want 1.0", conf)
+	}
+	if ver != "3.1" {
+		t.Errorf("version = %q, want 3.1", ver)
+	}
+}
+
+func TestCollectCustomDetectors(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("good.yaml", "name: ZZCustomTest\nsignatures:\n  - pattern: \"ZZCustomMarker\"\n    weight: 1.0\n")
+	write("bad.yaml", "name: \"\"\nsignatures: []\n") // invalid: skipped with a warning
+	write("ignore.txt", "not a signature file")       // wrong extension: ignored
+
+	got := collectCustomDetectors(dir)
+	if len(got) != 1 {
+		t.Fatalf("collected %d detectors, want 1 (good.yaml only)", len(got))
+	}
+	if got[0].Name() != "ZZCustomTest" {
+		t.Errorf("detector name = %q, want ZZCustomTest", got[0].Name())
+	}
+	if conf, _ := got[0].Detect("page with ZZCustomMarker", http.Header{}); conf != 1.0 {
+		t.Errorf("confidence = %v, want 1.0", conf)
+	}
+}
+
+func TestCollectCustomDetectorsMissingDir(t *testing.T) {
+	if got := collectCustomDetectors(filepath.Join(t.TempDir(), "nope")); got != nil {
+		t.Errorf("missing dir should yield nil, got %v", got)
+	}
+}

--- a/internal/scan/frameworks/detect.go
+++ b/internal/scan/frameworks/detect.go
@@ -40,8 +40,14 @@ type detectionResult struct {
 	version    string
 }
 
+// loadCustomOnce loads the user signature directory the first time a scan runs,
+// so config-defined detectors join the registry without a per-target re-read.
+var loadCustomOnce sync.Once
+
 // DetectFramework runs all registered detectors against the target URL.
 func DetectFramework(url string, timeout time.Duration, logdir string) (*FrameworkResult, error) {
+	loadCustomOnce.Do(loadCustomDetectors)
+
 	log := output.Module("FRAMEWORK")
 	log.Start()
 


### PR DESCRIPTION
load yaml-defined detectors from `~/.config/sif/signatures` (`AppData\Local` on windows),
mirroring the user-modules convention, so a framework sif does not ship can be detected without
a rebuild. they load lazily once per run from `DetectFramework` and register alongside the
built-ins. each file is one detector, scored by the same weighted signature match as the
built-ins; confidence is linear rather than their sigmoid (importing it would cycle), so a
detector clears the 0.5 threshold once its matched weights pass half. a name matching a
built-in overrides it and inherits that built-in's version patterns and cves, the same as a
user module. a single unparseable file warns and is skipped rather than failing the scan.
implements the custom-signature help-wanted item in contributing.

build/vet/lint clean, `go test ./internal/scan/frameworks/...` green.
