### PR TITLE
docs: require go 1.25 to match go.mod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When opening an issue, please use the search tool and make sure that the issue h
 
 ### Development
 
-To develop sif, you'll need version 1.23 or later of the Go toolchain. After making your changes, run the program using `go run ./cmd/sif` to make sure it compiles and runs properly.
+To develop sif, you'll need version 1.25 or later of the Go toolchain. After making your changes, run the program using `go run ./cmd/sif` to make sure it compiles and runs properly.
 
 _Nix users:_ the repository provides a flake that can be used to develop and run sif. Use `nix run`, `nix develop`, `nix build`, etc. Make sure to run `gomod2nix` if `go.mod` is changed.
 


### PR DESCRIPTION
`CONTRIBUTING.md` asks for go 1.23, but `go.mod` pins 1.25.7 and both the readme and
`docs/development.md` already say 1.25. bump the contributing doc so the stated toolchain floor
matches.
