### PR TITLE
feat(scan): broaden cloudstorage bucket name candidates

### DIFF
--- a/internal/scan/cloudstorage.go
+++ b/internal/scan/cloudstorage.go
@@ -84,15 +84,22 @@ func CloudStorage(url string, timeout time.Duration, logdir string) ([]CloudStor
 }
 
 func extractPotentialBuckets(url string) []string {
-	// TODO: handle non-adjacent label combos and strip the tld
-	parts := strings.Split(url, ".")
-	var buckets []string
-	for i, part := range parts {
-		buckets = append(buckets, part, part+"-s3", "s3-"+part)
+	labels := strings.Split(url, ".")
+	// drop the tld label so we don't waste guesses on it ("com", "com-s3", ...);
+	// a single-label host has no tld to strip.
+	if len(labels) > 1 {
+		labels = labels[:len(labels)-1]
+	}
 
-		if i < len(parts)-1 {
-			domainExtension := part + "-" + parts[i+1]
-			buckets = append(buckets, domainExtension, parts[i+1]+"-"+part)
+	var buckets []string
+	for _, label := range labels {
+		buckets = append(buckets, label, label+"-s3", "s3-"+label)
+	}
+	// combine every label with every other, not just adjacent ones, so a deep
+	// host like shop.cdn.example yields shop-example too.
+	for i, a := range labels {
+		for _, b := range labels[i+1:] {
+			buckets = append(buckets, a+"-"+b, b+"-"+a)
 		}
 	}
 	return buckets

--- a/internal/scan/cloudstorage_test.go
+++ b/internal/scan/cloudstorage_test.go
@@ -1,0 +1,62 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestExtractPotentialBuckets(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		want   []string // candidates that must be generated
+		absent []string // candidates that must not be generated
+	}{
+		{
+			name:   "strips the tld and pairs labels both ways",
+			host:   "shop.example.com",
+			want:   []string{"shop", "shop-s3", "s3-shop", "example", "shop-example", "example-shop"},
+			absent: []string{"com", "com-s3", "s3-com", "example-com", "com-example"},
+		},
+		{
+			name:   "combines non-adjacent labels",
+			host:   "a.b.c.example.com",
+			want:   []string{"a-c", "c-a", "a-example", "example-a", "b-example"},
+			absent: []string{"com", "example-com"},
+		},
+		{
+			name:   "single-label host keeps its only label and makes no pairs",
+			host:   "localhost",
+			want:   []string{"localhost", "localhost-s3", "s3-localhost"},
+			absent: []string{"localhost-localhost", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPotentialBuckets(tt.host)
+			for _, w := range tt.want {
+				if !slices.Contains(got, w) {
+					t.Errorf("extractPotentialBuckets(%q) missing %q; got %v", tt.host, w, got)
+				}
+			}
+			for _, a := range tt.absent {
+				if slices.Contains(got, a) {
+					t.Errorf("extractPotentialBuckets(%q) should not generate %q; got %v", tt.host, a, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
the `extractPotentialBuckets` TODO asked to handle non-adjacent label combos and strip the tld.
strip the trailing tld label so we stop guessing it (`com`, `com-s3`, `example-com`), and pair
every label with every other rather than only adjacent ones, so a deep host like
`shop.cdn.example` yields `shop-example` too. this widens the candidate set (and the s3 probes)
per host; multi-part suffixes like `.co.uk` still leave a junk label, which publicsuffix would
refine as a follow-up.

build/vet/lint clean, `go test ./internal/scan/` green.
