### PR TITLE
fix(scan): surface dirlist wordlist read errors

### DIFF
--- a/internal/scan/dirlist.go
+++ b/internal/scan/dirlist.go
@@ -303,7 +303,11 @@ func fetchWordlist(listURL string, client *http.Client) ([]string, error) {
 		return nil, fmt.Errorf("download wordlist %q: %w", listURL, err)
 	}
 	defer resp.Body.Close()
-	return scanLines(resp.Body), nil
+	lines, err := scanLines(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("download wordlist %q: %w", listURL, err)
+	}
+	return lines, nil
 }
 
 // readWordlistFile loads a local wordlist file.
@@ -313,11 +317,15 @@ func readWordlistFile(path string) ([]string, error) {
 		return nil, fmt.Errorf("open wordlist %q: %w", path, err)
 	}
 	defer f.Close()
-	return scanLines(f), nil
+	lines, err := scanLines(f)
+	if err != nil {
+		return nil, fmt.Errorf("read wordlist %q: %w", path, err)
+	}
+	return lines, nil
 }
 
 // scanLines reads non-empty lines into a slice.
-func scanLines(r io.Reader) []string {
+func scanLines(r io.Reader) ([]string, error) {
 	var lines []string
 	scanner := bufio.NewScanner(r)
 	scanner.Split(bufio.ScanLines)
@@ -327,7 +335,9 @@ func scanLines(r io.Reader) []string {
 			lines = append(lines, line)
 		}
 	}
-	return lines
+	// a line past bufio's 64k cap halts the scan; surface it instead of
+	// silently dropping that line and everything after it.
+	return lines, scanner.Err()
 }
 
 // calibrate probes a few paths that cannot exist and records the response shapes

--- a/internal/scan/dirlist_test.go
+++ b/internal/scan/dirlist_test.go
@@ -13,6 +13,8 @@
 package scan
 
 import (
+	"bufio"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -357,4 +359,25 @@ func pathSet(results DirectoryResults) map[string]struct{} {
 func has(set map[string]struct{}, key string) bool {
 	_, ok := set[key]
 	return ok
+}
+
+func TestScanLines(t *testing.T) {
+	got, err := scanLines(strings.NewReader("admin\n\nlogin\n"))
+	if err != nil {
+		t.Fatalf("scanLines: %v", err)
+	}
+	want := []string{"admin", "login"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("scanLines = %v, want %v", got, want)
+	}
+}
+
+func TestScanLinesErrorsOnOverlongLine(t *testing.T) {
+	// a line past bufio's 64k cap must surface as an error, not silently
+	// truncate the wordlist (dropping that line and everything after it).
+	huge := strings.Repeat("a", bufio.MaxScanTokenSize+1)
+	_, err := scanLines(strings.NewReader("first\n" + huge + "\nlast\n"))
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("scanLines err = %v, want bufio.ErrTooLong", err)
+	}
 }


### PR DESCRIPTION
`scanLines` used a default `bufio.Scanner` (64k token cap) and never checked `scanner.Err()`,
so a wordlist line past the cap silently halted the scan and dropped that line plus everything
after it. return the error so the wordlist loaders fail loud instead of running against a
truncated list.

build/vet/lint clean, `go test ./internal/scan/` green.
