### PR TITLE
fix(scan): read full body in js scanners

### DIFF
--- a/internal/scan/js/frameworks/next.go
+++ b/internal/scan/js/frameworks/next.go
@@ -23,9 +23,9 @@
 package frameworks
 
 import (
-	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -36,6 +36,10 @@ import (
 
 // nextPagesRegex matches JavaScript file references in Next.js build manifest.
 var nextPagesRegex = regexp.MustCompile(`\[("([^"]+\.js)"(,?))`)
+
+// maxManifestSize caps the build manifest read so a huge or hostile file
+// cannot exhaust memory.
+const maxManifestSize = 5 * 1024 * 1024
 
 func GetPagesRouterScripts(scriptUrl string) ([]string, error) {
 	baseUrl, err := urlutil.Parse(scriptUrl)
@@ -58,13 +62,14 @@ func GetPagesRouterScripts(scriptUrl string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	var sb strings.Builder
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		sb.WriteString(scanner.Text())
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestSize))
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
 	}
-	manifestText := sb.String()
+	// the manifest ships minified on one line; strip line breaks so the regex
+	// treats a (rare) pretty-printed one the same as the minified form.
+	manifestText := strings.NewReplacer("\r", "", "\n", "").Replace(string(body))
 
 	list := nextPagesRegex.FindAllStringSubmatch(manifestText, -1)
 

--- a/internal/scan/js/frameworks/next_test.go
+++ b/internal/scan/js/frameworks/next_test.go
@@ -1,0 +1,50 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package frameworks
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetPagesRouterScriptsReadsPastLongLine(t *testing.T) {
+	// a manifest token past bufio's 64k cap must not truncate the read and
+	// drop the script references that follow it.
+	huge := strings.Repeat("x", bufio.MaxScanTokenSize+1)
+	manifest := `["early.js"]` + "\n" + huge + "\n" + `["late.js"]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(manifest))
+	}))
+	defer srv.Close()
+
+	scripts, err := GetPagesRouterScripts(srv.URL + "/_buildManifest.js")
+	if err != nil {
+		t.Fatalf("GetPagesRouterScripts: %v", err)
+	}
+
+	found := func(needle string) bool {
+		for _, s := range scripts {
+			if strings.Contains(s, needle) {
+				return true
+			}
+		}
+		return false
+	}
+	if !found("early.js") || !found("late.js") {
+		t.Errorf("want both early.js and late.js, got %v", scripts)
+	}
+}

--- a/internal/scan/js/scan.go
+++ b/internal/scan/js/scan.go
@@ -13,7 +13,6 @@
 package js
 
 import (
-	"bufio"
 	"context"
 	"io"
 	"net/http"
@@ -64,6 +63,10 @@ func (r *JavascriptScanResult) SupabaseFindings() []SupabaseFinding {
 	return out
 }
 
+// maxHTMLBodySize caps how much of a page we read for script extraction so a
+// huge or hostile response cannot exhaust memory.
+const maxHTMLBodySize = 5 * 1024 * 1024
+
 func JavascriptScan(url string, timeout time.Duration, threads int, logdir string) (*JavascriptScanResult, error) {
 	log := output.Module("JS")
 	log.Start()
@@ -90,15 +93,7 @@ func JavascriptScan(url string, timeout time.Duration, threads int, logdir strin
 	}
 	defer resp.Body.Close()
 
-	var sb strings.Builder
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		sb.WriteString(scanner.Text())
-	}
-	html := sb.String()
-
-	doc, err := htmlquery.Parse(strings.NewReader(html))
+	doc, err := htmlquery.Parse(io.LimitReader(resp.Body, maxHTMLBodySize))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the page scanner and the next.js manifest parser both reassembled the response body line by
line with a default `bufio.Scanner` (64k token cap), so a line past the cap (common with
minified or inlined js) silently halted the read and dropped every script and route reference
after it. read the whole body instead, capped at 5mb. parsing the raw page bytes also fixes
script tags split across a newline, which the old line-joined reassembly merged and missed.

build/vet/lint clean, `go test ./internal/scan/js/...` green.
