### PR TITLE
fix(scan): require a wordpress marker on probed wp paths

### DIFF
--- a/internal/scan/cms.go
+++ b/internal/scan/cms.go
@@ -128,12 +128,23 @@ func detectWordPress(url string, client *http.Client, bodyString string) bool {
 		if err != nil {
 			continue
 		}
-		resp, err := client.Do(req) //nolint:bodyclose // drained and closed via httpx.DrainClose
-		if err == nil {
-			found := resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusFound
-			// status only; drain so the conn returns to the pool.
-			httpx.DrainClose(resp)
-			if found {
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+		resp.Body.Close()
+		if err != nil {
+			continue
+		}
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusFound {
+			continue
+		}
+		// the client follows redirects, so soft-404 and catch-all sites also land
+		// here with a 200; require an actual WordPress marker in the body.
+		probeBody := string(body)
+		for _, indicator := range wpIndicators {
+			if strings.Contains(probeBody, indicator) {
 				return true
 			}
 		}

--- a/internal/scan/cms_wordpress_probe_test.go
+++ b/internal/scan/cms_wordpress_probe_test.go
@@ -1,0 +1,102 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// a soft-404 (200 for every path) is not wordpress; a bare 200 on the probe must
+// not flag without a marker in the body.
+func TestDetectWordPress_SoftFourOhFourNotFlagged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html><body>welcome to my static site</body></html>"))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	if detectWordPress(srv.URL, client, "<html><body>welcome to my static site</body></html>") {
+		t.Error("soft-404 site (200 for every path, no wordpress markers) wrongly detected as WordPress")
+	}
+}
+
+// a catch-all 302 is followed to a non-wordpress 200; without a marker it must
+// not flag.
+func TestDetectWordPress_CatchAllRedirectNotFlagged(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/home", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html><body>landing page</body></html>"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/home", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	if detectWordPress(srv.URL, client, "<html><body>landing page</body></html>") {
+		t.Error("catch-all 302 redirect to a non-wordpress homepage wrongly detected as WordPress")
+	}
+}
+
+// a real wp-login.php response references wp-includes assets even when the
+// homepage hides its wordpress markers, so the file probe should still detect it.
+func TestDetectWordPress_LoginPageProbeDetected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/wp-login.php" {
+			_, _ = w.Write([]byte(`<link rel="stylesheet" href="/wp-includes/css/dashicons.min.css">`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	if !detectWordPress(srv.URL, client, "<html><body>custom theme, no markers</body></html>") {
+		t.Error("wp-login.php referencing wp-includes assets should be detected as WordPress")
+	}
+}
+
+// end-to-end through CMS() with the real redirect-following client: a soft-404
+// host must not be reported as a CMS.
+func TestCMS_SoftFourOhFourNotWordPress(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html><body>welcome to my static site</body></html>"))
+	}))
+	defer srv.Close()
+
+	result, err := CMS(srv.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("CMS: %v", err)
+	}
+	if result != nil {
+		t.Errorf("soft-404 host wrongly classified as CMS %q", result.Name)
+	}
+}
+
+// a probe that hits a redirect loop errors out in the client; it must be skipped
+// gracefully, never panicking or counting as a detection.
+func TestDetectWordPress_RedirectLoopHandled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/loop", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	if detectWordPress(srv.URL, client, "<html><body>no markers</body></html>") {
+		t.Error("redirect loop wrongly detected as WordPress")
+	}
+}


### PR DESCRIPTION
`detectWordPress` treated any 2xx on `/wp-login.php`, `/wp-admin/` or `/wp-config.php` as
wordpress, but the http client follows redirects and many sites soft-404 (200 for every path)
or catch-all redirect to their homepage, so a probed path returns 200 without being wordpress:
plain static sites and marketing pages were flagged. read the probed response and require one
of the existing wordpress markers in its body before counting it; a real `/wp-login.php` still
references `wp-includes` assets, so genuine detection holds.

build/vet/lint clean, `go test ./internal/scan/` green.
