### PR TITLE
fix(scan): detect modern drupal by its headers

### DIFF
--- a/internal/scan/cms.go
+++ b/internal/scan/cms.go
@@ -78,7 +78,7 @@ func CMS(url string, timeout time.Duration, logdir string) (*CMSResult, error) {
 	}
 
 	// Drupal
-	if strings.Contains(resp.Header.Get("X-Drupal-Cache"), "HIT") || strings.Contains(bodyString, "Drupal.settings") {
+	if detectDrupal(resp.Header, bodyString) {
 		spin.Stop()
 		result := &CMSResult{Name: "Drupal", Version: "Unknown"}
 		log.Success("Detected CMS: %s", output.Highlight.Render(result.Name))
@@ -159,4 +159,15 @@ func detectJoomla(body string) bool {
 	return strings.Contains(body, `generator" content="Joomla!`) ||
 		strings.Contains(body, "/media/vendor/joomla") ||
 		strings.Contains(body, "/media/system/js/core.js")
+}
+
+// detectDrupal reports whether the response looks like Drupal. the X-Drupal-* and
+// X-Generator headers survive cdn caching when the body markers do not, and an
+// X-Drupal-Cache of any value (even MISS) is a tell.
+func detectDrupal(header http.Header, body string) bool {
+	return strings.Contains(header.Get("X-Generator"), "Drupal") ||
+		header.Get("X-Drupal-Cache") != "" ||
+		header.Get("X-Drupal-Dynamic-Cache") != "" ||
+		strings.Contains(body, "Drupal.settings") ||
+		strings.Contains(body, "drupalSettings")
 }

--- a/internal/scan/cms_drupal_test.go
+++ b/internal/scan/cms_drupal_test.go
@@ -1,0 +1,69 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// header cases mirror live Drupal 8-11 (acquia, georgia, london): the X-Drupal-*
+// and X-Generator headers tell even when the body has no marker.
+func TestDetectDrupal_ModernSignals(t *testing.T) {
+	cases := []struct {
+		name   string
+		header http.Header
+		body   string
+		want   bool
+	}{
+		{"x-generator drupal 10", http.Header{"X-Generator": {"Drupal 10 (https://www.drupal.org)"}}, "", true},
+		{"x-drupal-cache miss", http.Header{"X-Drupal-Cache": {"MISS"}}, "", true},
+		{"x-drupal-dynamic-cache", http.Header{"X-Drupal-Dynamic-Cache": {"HIT"}}, "", true},
+		{"drupalSettings body (8+)", http.Header{}, `<script>window.drupalSettings = {};</script>`, true},
+		{"Drupal.settings body (7)", http.Header{}, `<script>Drupal.settings = {};</script>`, true},
+		{"plain page", http.Header{"Server": {"nginx"}}, "<html><body>hello</body></html>", false},
+		{"x-generator wordpress", http.Header{"X-Generator": {"WordPress 6.5"}}, "", false},
+		{"bare drupal prose", http.Header{}, "we migrated off Drupal CMS last year", false},
+	}
+	for _, c := range cases {
+		if got := detectDrupal(c.header, c.body); got != c.want {
+			t.Errorf("%s: detectDrupal = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// end-to-end: a modern Drupal whose only tell is X-Drupal-Dynamic-Cache (the live
+// london.gov.uk case) must be detected.
+func TestCMS_ModernDrupalDetected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// a real Drupal site has no wordpress paths; 404 them so the wordpress
+		// probe does not claim the host before the Drupal check runs.
+		if r.URL.Path != "/" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("X-Drupal-Dynamic-Cache", "MISS")
+		_, _ = w.Write([]byte("<html><body>news and updates</body></html>"))
+	}))
+	defer srv.Close()
+
+	result, err := CMS(srv.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("CMS: %v", err)
+	}
+	if result == nil || result.Name != "Drupal" {
+		t.Errorf("modern Drupal (X-Drupal-Dynamic-Cache) not detected, got %+v", result)
+	}
+}


### PR DESCRIPTION
the cms check only flagged drupal on `X-Drupal-Cache: HIT` or the drupal 7 `Drupal.settings`
marker, so drupal 8-11 went undetected: a MISS header was ignored and cdn-fronted sites serve
none of those markers in the body. verified live that london.gov.uk and georgia.gov (both
drupal) were missed. key on the drupal-specific headers instead: any
`X-Drupal-Cache`/`X-Drupal-Dynamic-Cache` plus `X-Generator` naming drupal (these survive cdn
caching), with `drupalSettings` (8+) and `Drupal.settings` (7) covering uncached bodies.

build/vet/lint clean, `go test ./internal/scan/` green.
