### PR TITLE
fix(scan): drop the bare wordpress detection marker

### DIFF
--- a/internal/scan/cms.go
+++ b/internal/scan/cms.go
@@ -102,12 +102,12 @@ func CMS(url string, timeout time.Duration, logdir string) (*CMSResult, error) {
 }
 
 func detectWordPress(url string, client *http.Client, bodyString string) bool {
-	// Check for common WordPress indicators in the HTML
+	// wordpress asset paths only; the bare word "wordpress" matched pages that
+	// merely mention it (wp-hosting marketing), so it is dropped.
 	wpIndicators := []string{
 		"wp-content",
 		"wp-includes",
 		"wp-json",
-		"wordpress",
 	}
 
 	for _, indicator := range wpIndicators {

--- a/internal/scan/cms_wordpress_mention_test.go
+++ b/internal/scan/cms_wordpress_mention_test.go
@@ -1,0 +1,49 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// notFound serves 404 for every path so the file probe never fires; only the
+// passed homepage body decides the result.
+func notFound(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// a page that only mentions wordpress in prose (no asset paths) is not running it.
+func TestDetectWordPress_BareMentionNotFlagged(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	body := "<html><body>we offer managed wordpress hosting</body></html>"
+	if detectWordPress(notFound(t), client, body) {
+		t.Error("a page merely mentioning wordpress was flagged as WordPress")
+	}
+}
+
+// a real wordpress homepage references wp-content asset paths.
+func TestDetectWordPress_AssetPathsDetected(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	body := `<link href="/wp-content/themes/x/style.css">`
+	if !detectWordPress(notFound(t), client, body) {
+		t.Error("wp-content asset path should be detected as WordPress")
+	}
+}


### PR DESCRIPTION
`detectWordPress` flagged any page whose body merely contained the word `wordpress`, so sites
that only mention it (wp-hosting marketing, comparison pages) were misreported: acquia.com, a
drupal site, was detected as wordpress. `wp-content`, `wp-includes` and `wp-json` already
identify a real install and appear on every wordpress page, so the bare word adds only false
positives. drop it.

build/vet/lint clean, `go test ./internal/scan/` green.
