### PR TITLE
fix(scan): flag openapi operations reachable without authentication

### DIFF
--- a/internal/scan/openapi.go
+++ b/internal/scan/openapi.go
@@ -92,10 +92,10 @@ type openapiInfo struct {
 	Version string `json:"version" yaml:"version"`
 }
 
-// rawOps captures just the per-operation security block so we can tell whether
-// an operation requires auth. the rest of the operation object is irrelevant.
+// rawOps captures the per-operation security block. a pointer so an absent block
+// (inherit global) is distinct from an explicit empty one (security: [] = public).
 type rawOps struct {
-	Security []map[string][]string `json:"security" yaml:"security"`
+	Security *[]map[string][]string `json:"security" yaml:"security"`
 }
 
 // OpenAPI probes the candidate spec paths concurrently and, on the first hit,
@@ -252,11 +252,26 @@ func parseOpenAPISpec(body []byte) (*openapiSpec, bool) {
 	return &spec, true
 }
 
+// securityAllowsAnonymous reports whether a security requirement list lets a
+// caller through without credentials: an empty list (security: []) or an empty
+// requirement object ({}) inside it both permit anonymous access.
+func securityAllowsAnonymous(reqs []map[string][]string) bool {
+	if len(reqs) == 0 {
+		return true
+	}
+	for _, req := range reqs {
+		if len(req) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // specToResult flattens the parsed spec into enumerated endpoints and ranks the
-// exposure. an operation with no security requirement (and no top-level default)
-// is flagged unauthenticated, which bumps the overall severity to high.
+// exposure. an operation is flagged unauthenticated when its effective security
+// permits anonymous access, which bumps the overall severity to high.
 func specToResult(spec *openapiSpec) *OpenAPIResult {
-	hasGlobalSecurity := len(spec.Security) > 0
+	globalAllowsAnon := securityAllowsAnonymous(spec.Security)
 
 	endpoints := make([]OpenAPIEndpoint, 0, len(spec.Paths))
 	anyUnauth := false
@@ -277,9 +292,13 @@ func specToResult(spec *openapiSpec) *OpenAPIResult {
 			if !ok {
 				continue
 			}
-			// an operation is unauth when neither it nor the global default
-			// declares a security requirement.
-			unauth := len(op.Security) == 0 && !hasGlobalSecurity
+			// an explicit block decides on its own; an absent one inherits global.
+			var unauth bool
+			if op.Security != nil {
+				unauth = securityAllowsAnonymous(*op.Security)
+			} else {
+				unauth = globalAllowsAnon
+			}
 			if unauth {
 				anyUnauth = true
 			}

--- a/internal/scan/openapi_test.go
+++ b/internal/scan/openapi_test.go
@@ -56,6 +56,35 @@ paths:
       summary: health
 `
 
+// a globally-secured spec mixing public opt-outs (security: [] and security: [{}])
+// with operations that inherit or declare their own requirement.
+const openapiJSONPublicOverride = `{
+  "openapi": "3.0.1",
+  "info": {"title": "Override API", "version": "1.0"},
+  "security": [{"bearerAuth": []}],
+  "paths": {
+    "/me":       {"get": {"summary": "authed, inherits global"}},
+    "/admin":    {"get": {"summary": "authed, explicit non-empty", "security": [{"bearerAuth": []}]}},
+    "/login":    {"post": {"summary": "public override", "security": []}},
+    "/optional": {"get": {"summary": "anonymous allowed", "security": [{}]}}
+  }
+}`
+
+// a yaml spec with global auth and an operation that opts out via security: [],
+// to lock the empty-vs-absent distinction on the yaml decode path too.
+const openapiYAMLPublicOverride = `openapi: "3.0.1"
+info:
+  title: YAML Override API
+  version: "1.0"
+security:
+  - bearerAuth: []
+paths:
+  /token:
+    post:
+      summary: public
+      security: []
+`
+
 // hasEndpoint reports whether the result enumerated the given path+method.
 func hasEndpoint(r *OpenAPIResult, path, method string) (OpenAPIEndpoint, bool) {
 	for i := 0; i < len(r.Endpoints); i++ {
@@ -138,6 +167,81 @@ func TestOpenAPI_SecuredSpecIsMedium(t *testing.T) {
 	}
 	if result.Severity != openapiSevMedium {
 		t.Errorf("expected medium severity for a secured spec, got %q", result.Severity)
+	}
+}
+
+// TestOpenAPI_PublicOverridesAreUnauth checks that operations allowing anonymous
+// access (security: [] or security: [{}]) are flagged unauthenticated, while ones
+// that inherit the enforced global default or declare their own requirement stay authed.
+func TestOpenAPI_PublicOverridesAreUnauth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi.json" {
+			_, _ = w.Write([]byte(openapiJSONPublicOverride))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	result, err := OpenAPI(srv.URL, 5*time.Second, 4, "")
+	if err != nil {
+		t.Fatalf("OpenAPI: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a result, got nil")
+	}
+
+	for _, want := range []struct {
+		path, method string
+		unauth       bool
+		why          string
+	}{
+		{"/login", http.MethodPost, true, "security: [] removes the global requirement"},
+		{"/optional", http.MethodGet, true, "security: [{}] permits anonymous access"},
+		{"/me", http.MethodGet, false, "inherits the enforced global requirement"},
+		{"/admin", http.MethodGet, false, "declares its own non-empty requirement"},
+	} {
+		ep, ok := hasEndpoint(result, want.path, want.method)
+		if !ok {
+			t.Fatalf("expected %s %s to be enumerated", want.method, want.path)
+		}
+		if ep.Unauth != want.unauth {
+			t.Errorf("%s %s unauth=%v, want %v (%s)", want.method, want.path, ep.Unauth, want.unauth, want.why)
+		}
+	}
+
+	if result.Severity != openapiSevHigh {
+		t.Errorf("an unauthenticated operation should rank the exposure high, got %q", result.Severity)
+	}
+}
+
+// TestOpenAPI_YAMLPublicOverrideIsUnauth locks the empty-vs-absent distinction on
+// the yaml decode path: yaml.v3 must preserve security: [] as a non-nil empty
+// block, or the whole fix silently regresses on yaml specs.
+func TestOpenAPI_YAMLPublicOverrideIsUnauth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/api-docs" {
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte(openapiYAMLPublicOverride))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	result, err := OpenAPI(srv.URL, 5*time.Second, 4, "")
+	if err != nil {
+		t.Fatalf("OpenAPI: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a yaml result, got nil")
+	}
+	ep, ok := hasEndpoint(result, "/token", http.MethodPost)
+	if !ok {
+		t.Fatal("expected /token POST to be enumerated")
+	}
+	if !ep.Unauth {
+		t.Error("yaml security: [] should be flagged unauthenticated; yaml.v3 must keep it non-nil")
 	}
 }
 


### PR DESCRIPTION
`specToResult` computed an operation's auth status with `len(op.Security) == 0`, which a value
slice cannot tell apart from an absent block: an operation that overrides the global
requirement with an empty array (`security: []`) or an empty requirement object
(`security: [{}]`) decoded the same as one that simply inherits the global default, so those
deliberately-public endpoints were reported as authenticated. decode the operation security
into a pointer to keep absent distinct from explicit-empty, and treat both empty forms as
anonymous-reachable.

build/vet/lint clean, `go test ./internal/scan/` green.
