### PR TITLE
fix(scan): accept quoted hsts max-age values

### DIFF
--- a/internal/scan/securityheaders.go
+++ b/internal/scan/securityheaders.go
@@ -151,7 +151,9 @@ func gradeSecurityHeaders(header http.Header, https bool) SecurityHeaderResults 
 func hstsMaxAge(value string) int {
 	for _, part := range strings.Split(value, ";") {
 		if age, ok := strings.CutPrefix(strings.ToLower(strings.TrimSpace(part)), "max-age="); ok {
-			n, err := strconv.Atoi(strings.TrimSpace(age))
+			// rfc 6797 allows a quoted-string value
+			age = strings.Trim(strings.TrimSpace(age), `"`)
+			n, err := strconv.Atoi(age)
 			if err != nil {
 				return 0
 			}

--- a/internal/scan/securityheaders_test.go
+++ b/internal/scan/securityheaders_test.go
@@ -110,6 +110,28 @@ func TestGradeSecurityHeaders_WeakHSTS(t *testing.T) {
 	}
 }
 
+func TestGradeSecurityHeaders_QuotedHSTS(t *testing.T) {
+	// rfc 6797 allows a quoted value; strip the quotes before grading
+	tests := []struct {
+		name    string
+		value   string
+		flagged bool
+	}{
+		{"quoted strong", `max-age="63072000"; includeSubDomains`, false},
+		{"quoted weak still flagged", `max-age="0"`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := buildHeader(map[string]string{"Strict-Transport-Security": tt.value})
+			_, flagged := findFinding(gradeSecurityHeaders(h, true), "Strict-Transport-Security")
+			if flagged != tt.flagged {
+				t.Errorf("value %q flagged=%v, want %v", tt.value, flagged, tt.flagged)
+			}
+		})
+	}
+}
+
 func TestGradeSecurityHeaders_Disclosure(t *testing.T) {
 	h := buildHeader(map[string]string{
 		"Server":       "Apache/2.4.1 (Ubuntu)",


### PR DESCRIPTION
rfc 6797 permits a quoted-string directive value, so a quoted `max-age="31536000"` failed
`strconv.Atoi` and got flagged as too short. strip the quotes before parsing.

build/vet/lint clean, `go test ./internal/scan/` green.
