### PR TITLE
fix(scan): add opt-in soft-404 baseline to db panel scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sif has a modular architecture. modules are defined in yaml and can be extended 
 | `-fs` | dirlist: filter out responses of these body sizes (comma list) |
 | `-fw` | dirlist: filter out responses with these word counts (comma list) |
 | `-fr` | dirlist: filter out responses whose body matches this regex |
-| `-ac` | dirlist: auto-calibrate the soft-404 wildcard baseline |
+| `-ac` | auto-calibrate the soft-404 wildcard baseline (dirlist, sql) |
 | `-w` | dirlist: custom wordlist (local file or url; overrides `-dirlist` size) |
 | `-e` | dirlist: extensions appended to each word (comma list, e.g. php,bak,env) |
 | `-dnslist` | subdomain enumeration (small/medium/large) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Settings struct {
 	DirFilterSizes    string // -fs dirlist: body sizes to drop
 	DirFilterWords    string // -fw dirlist: word counts to drop
 	DirFilterRegex    string // -fr dirlist: regex; body match drops response
-	DirCalibrate      bool   // -ac dirlist: auto-calibrate soft-404 baseline
+	Calibrate         bool   // -ac auto-calibrate the soft-404 baseline (dirlist, sql)
 	DirWordlist       string // -w  dirlist: custom wordlist (file path or url)
 	DirExtensions     string // -e  dirlist: extensions appended to each word
 	Dnslist           string
@@ -130,7 +130,7 @@ func Parse() *Settings {
 		flagSet.StringVar(&settings.DirFilterSizes, "fs", "", "Dirlist: filter out responses of these body sizes (comma list)"),
 		flagSet.StringVar(&settings.DirFilterWords, "fw", "", "Dirlist: filter out responses with these word counts (comma list)"),
 		flagSet.StringVar(&settings.DirFilterRegex, "fr", "", "Dirlist: filter out responses whose body matches this regex"),
-		flagSet.BoolVar(&settings.DirCalibrate, "ac", false, "Dirlist: auto-calibrate the soft-404 wildcard baseline"),
+		flagSet.BoolVar(&settings.Calibrate, "ac", false, "Auto-calibrate the soft-404 wildcard baseline (dirlist, sql)"),
 		flagSet.StringVar(&settings.DirWordlist, "w", "", "Dirlist: custom wordlist (local file path or url; overrides -dirlist size)"),
 		flagSet.StringVar(&settings.DirExtensions, "e", "", "Dirlist: extensions appended to each word (comma list, e.g. php,bak,env)"),
 		flagSet.EnumVar(&settings.Dnslist, "dnslist", Nil, "DNS fuzzing scan size (small/medium/large)", listSizes),

--- a/internal/scan/sql.go
+++ b/internal/scan/sql.go
@@ -115,7 +115,7 @@ var databaseErrorPatterns = []struct {
 }
 
 // SQL performs SQL reconnaissance on the target URL
-func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*SQLResult, error) {
+func SQL(targetURL string, timeout time.Duration, threads int, logdir string, calibrate bool) (*SQLResult, error) {
 	log := output.Module("SQL")
 	log.Start()
 
@@ -149,6 +149,15 @@ func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*
 		return nil
 	}
 
+	// a catch-all that answers 200/403/401 for every path would make each probe
+	// look like a hit. with -ac, calibrate the soft-404 wildcard shape first (as
+	// dirlist does) and drop probes whose shape matches it before isAdminPanel.
+	// off by default so the scan keeps reporting every hit unless asked otherwise.
+	var baselines []responseMeta
+	if calibrate {
+		baselines = calibrateSQLBaseline(targetURL, client)
+	}
+
 	// check for admin panels
 	wg.Add(threads)
 	adminPathsChan := make(chan int, len(sqlAdminPaths))
@@ -178,9 +187,12 @@ func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*
 				// check for successful response (not 404)
 				if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
 					// read body to check for common admin panel indicators
-					body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*100)) // limit to 100KB
+					meta, body := readMeta(resp)
 					resp.Body.Close()
-					if err != nil {
+
+					// a catch-all hands the same shape to every path; drop it so a
+					// wildcard 200/403/401 is not reported as an admin panel.
+					if containsBaseline(baselines, meta) {
 						continue
 					}
 					bodyStr := string(body)
@@ -254,6 +266,36 @@ func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*
 
 	log.Complete(totalFindings, "found")
 	return result, nil
+}
+
+// calibrateSQLBaseline probes paths that cannot exist and records the response
+// shapes a catch-all returns, so soft-404 200/403/401 pages are suppressed before
+// isAdminPanel runs. deterministic: probe suffixes come from the loop index.
+func calibrateSQLBaseline(targetURL string, client *http.Client) []responseMeta {
+	base := strings.TrimSuffix(targetURL, "/")
+	var baselines []responseMeta
+	for i := 0; i < calibrationProbes; i++ {
+		probe := base + calibrationPrefix + strconv.Itoa(i) + "/"
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, probe, http.NoBody)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		meta, _ := readMeta(resp)
+		resp.Body.Close()
+		// a hard 404 is already filtered by status; only soft 200/403/401 shapes
+		// need a baseline to suppress them.
+		if meta.status == statusNotFound {
+			continue
+		}
+		if !containsBaseline(baselines, meta) {
+			baselines = append(baselines, meta)
+		}
+	}
+	return baselines
 }
 
 func isAdminPanel(body string, panelType string) bool {

--- a/internal/scan/sql_soft404_test.go
+++ b/internal/scan/sql_soft404_test.go
@@ -1,0 +1,229 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// representative bodies. these are not padded to force a size delta: a generic
+// homepage and a real admin login simply have different content, hence different
+// shapes. the catch-all body carries no db keyword so the comparison turns on the
+// baseline, not on isAdminPanel.
+const (
+	catchAllHome = `<!DOCTYPE html><html><head><title>Acme</title></head>` +
+		`<body><nav>Home About Contact</nav><main>Welcome to Acme.</main></body></html>`
+
+	realPMALogin = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">` +
+		`<title>phpMyAdmin</title><link rel="stylesheet" href="phpmyadmin.css.php"></head>` +
+		`<body class="loginform"><form method="post" action="index.php"><fieldset>` +
+		`<legend>Log in to phpMyAdmin</legend>` +
+		`<label>Username</label><input type="text" name="pma_username">` +
+		`<label>Password</label><input type="password" name="pma_password">` +
+		`<input type="submit" value="Go"></fieldset></form></body></html>`
+
+	realDBAdmin = `<!DOCTYPE html><html><head><title>Database Manager</title></head>` +
+		`<body><h1>MySQL Server 8.0</h1><table><tr><th>Database</th><th>Tables</th></tr>` +
+		`<tr><td>app_production</td><td>42</td></tr></table>` +
+		`<form action="/run"><textarea name="sql">SELECT 1</textarea><button>Run</button></form>` +
+		`</body></html>`
+)
+
+// countAdminPanels is nil-safe: SQL returns a nil result when nothing is found.
+func countAdminPanels(r *SQLResult) int {
+	if r == nil {
+		return 0
+	}
+	return len(r.AdminPanels)
+}
+
+// hasPanelType reports whether a panel of the given type was found.
+func hasPanelType(r *SQLResult, panelType string) bool {
+	if r == nil {
+		return false
+	}
+	for _, p := range r.AdminPanels {
+		if p.Type == panelType {
+			return true
+		}
+	}
+	return false
+}
+
+// a 200 catch-all (the SPA wildcard) is calibrated as a baseline shape.
+func TestCalibrateSQLBaseline_CatchAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(catchAllHome))
+	}))
+	defer srv.Close()
+
+	baselines := calibrateSQLBaseline(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	if len(baselines) == 0 {
+		t.Fatal("a 200 catch-all should produce at least one baseline shape")
+	}
+}
+
+// a server that hard-404s every bogus path needs no baseline (status already filters).
+func TestCalibrateSQLBaseline_HardNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	baselines := calibrateSQLBaseline(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	if len(baselines) != 0 {
+		t.Errorf("hard-404 server should yield no baseline, got %d", len(baselines))
+	}
+}
+
+// with -ac on, a 200 catch-all serving a db-topical page at every path yields no
+// admin-panel finding once the wildcard shape is calibrated.
+func TestSQL_CatchAllSuppressed(t *testing.T) {
+	page := "<html><body>database dashboard for our service</body></html>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if n := countAdminPanels(result); n != 0 {
+		t.Errorf("catch-all produced %d admin-panel finding(s) with -ac, want 0", n)
+	}
+}
+
+// a 403 WAF that blanket-blocks with a db-mentioning page is also a catch-all and
+// must be suppressed (covers the 403 branch of the status set).
+func TestSQL_403WAFCatchAllSuppressed(t *testing.T) {
+	page := "Request blocked: possible sql injection attempt detected"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if n := countAdminPanels(result); n != 0 {
+		t.Errorf("403 WAF catch-all produced %d admin-panel finding(s) with -ac, want 0", n)
+	}
+}
+
+// suppression is opt-in: with -ac off (the default) the same catch-all is still
+// reported, matching dirlist's behavior.
+func TestSQL_CalibrateDisabledStillReports(t *testing.T) {
+	page := "<html><body>database dashboard for our service</body></html>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", false)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if countAdminPanels(result) == 0 {
+		t.Error("with -ac off, the catch-all should still be reported (suppression is opt-in)")
+	}
+}
+
+// a real phpMyAdmin hosted on a catch-all is still reported under -ac: a genuine
+// login page is a different shape than the wildcard homepage, so it is not dropped.
+func TestSQL_RealPanelAmongCatchAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/phpmyadmin/" {
+			_, _ = w.Write([]byte(realPMALogin))
+			return
+		}
+		_, _ = w.Write([]byte(catchAllHome))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if !hasPanelType(result, "phpMyAdmin") {
+		t.Errorf("real phpMyAdmin on a catch-all should still be reported; panels=%d",
+			countAdminPanels(result))
+	}
+}
+
+// a real generic interface (a distinct db admin page at /db/) is still reported
+// under -ac, so calibration does not over-suppress genuine findings.
+func TestSQL_RealGenericPanelAmongCatchAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/db/" {
+			_, _ = w.Write([]byte(realDBAdmin))
+			return
+		}
+		_, _ = w.Write([]byte(catchAllHome))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if countAdminPanels(result) == 0 {
+		t.Error("a real database interface at /db/ on a catch-all should still be reported")
+	}
+}
+
+// the normal case (no catch-all): a host that 404s everything except a real
+// phpMyAdmin still reports it, since calibration finds no baseline.
+func TestSQL_HardNotFoundRealPanelReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/phpmyadmin/" {
+			_, _ = w.Write([]byte(realPMALogin))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if !hasPanelType(result, "phpMyAdmin") {
+		t.Error("phpMyAdmin on a non-catch-all host should be reported")
+	}
+}
+
+// characterization of a known limitation (shared with dirlist): a catch-all that
+// reflects the request path varies its shape per path, so exact-shape calibration
+// cannot suppress it. this pins current behavior on purpose: if it fails, the
+// matching got stricter (the gap closed) and the test should be updated to expect 0.
+func TestSQL_ReflectedPathCatchAllNotSuppressed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "<html><body>no such page: %s (database)</body></html>", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if countAdminPanels(result) == 0 {
+		t.Error("reflected-path catch-all was suppressed; the gap closed, update this test to expect 0")
+	}
+}

--- a/sif.go
+++ b/sif.go
@@ -354,7 +354,7 @@ func (app *App) Run() error {
 				FilterSizes: app.settings.DirFilterSizes,
 				FilterWords: app.settings.DirFilterWords,
 				FilterRegex: app.settings.DirFilterRegex,
-				Calibrate:   app.settings.DirCalibrate,
+				Calibrate:   app.settings.Calibrate,
 				Wordlist:    app.settings.DirWordlist,
 				Extensions:  app.settings.DirExtensions,
 			})
@@ -498,7 +498,7 @@ func (app *App) Run() error {
 		}
 
 		if app.settings.SQL {
-			result, err := scan.SQL(url, app.settings.Timeout, app.settings.Threads, app.settings.LogDir)
+			result, err := scan.SQL(url, app.settings.Timeout, app.settings.Threads, app.settings.LogDir, app.settings.Calibrate)
 			if err != nil {
 				log.Errorf("Error while running SQL reconnaissance: %s", err)
 			} else if result != nil {


### PR DESCRIPTION
the admin-panel probe trusted any 200/403/401 at a generic db path, so a catch-all that answers every path was reported as a high-severity database admin panel whenever its page merely mentioned a db keyword.

under -ac (the same flag dirlist uses), calibrate the wildcard response shape first and drop probes whose status/size/words match it before isAdminPanel runs. off by default, so the scan keeps reporting every hit unless asked. matching is exact-shape, so a catch-all that reflects the request path is not suppressed.