### PR TITLE
fix(scan): tolerate reflected-path catch-alls in soft-404 calibration

### DIFF
--- a/internal/scan/dirlist.go
+++ b/internal/scan/dirlist.go
@@ -50,8 +50,9 @@ const dirlistBodyCap = 512 * 1024
 // cannot exist, then treat any response shape they share as the wildcard
 // baseline. deterministic (no rng) so the workflow stays reproducible.
 const (
-	calibrationProbes = 3
-	calibrationPrefix = "/sif-cal-"
+	calibrationProbes  = 3
+	calibrationPrefix  = "/sif-cal-"
+	calibrationPadStep = 8 // per-probe suffix growth; see calibrationSuffix
 )
 
 // statusNotFound / statusForbidden are the historical default "not interesting"
@@ -88,6 +89,20 @@ type responseMeta struct {
 	status int
 	size   int
 	words  int
+}
+
+// anySize, as a baseline size, marks a catch-all whose body size is unreliable (it
+// reflects the request path), so the baseline matches on status and word count alone.
+const anySize = -1
+
+// matchesBaseline reports whether meta looks like the calibrated soft-404 shape b.
+// a normal baseline compares status, size and words exactly; a reflecting catch-all
+// (b.size == anySize) compares status and words only, since its size is not stable.
+func (b responseMeta) matchesBaseline(meta responseMeta) bool {
+	if b.status != meta.status || b.words != meta.words {
+		return false
+	}
+	return b.size == anySize || b.size == meta.size
 }
 
 // matcher decides whether a response is "interesting" using the same precedence
@@ -154,13 +169,10 @@ func newMatcher(opts *DirlistOptions) (*matcher, error) {
 // over matches: a calibrated baseline, an -fc/-fs/-fw hit, or an -fr body match
 // always drops the response; otherwise the -mc set (when set) gates it.
 func (m *matcher) Matches(meta responseMeta, body []byte) bool {
-	// a calibrated soft-404 shape is the same response the catch-all hands every
-	// bogus path, so drop anything that matches a baseline exactly.
-	for i := 0; i < len(m.baselines); i++ {
-		b := m.baselines[i]
-		if b.status == meta.status && b.size == meta.size && b.words == meta.words {
-			return false
-		}
+	// a calibrated soft-404 shape is the response the catch-all hands every bogus
+	// path, so drop anything matching a baseline.
+	if containsBaseline(m.baselines, meta) {
+		return false
 	}
 
 	if _, drop := m.filterCodes[meta.status]; drop {
@@ -332,11 +344,18 @@ func scanLines(r io.Reader) []string {
 
 // calibrate probes a few paths that cannot exist and records the response shapes
 // the catch-all hands them. those baselines feed the matcher so a soft-404 200
-// (the SPA wildcard) is suppressed before the real run. deterministic by design:
-// the probe paths come from the loop index, never a random source.
+// (the SPA wildcard) is suppressed before the real run.
 func calibrate(m *matcher, baseURL string, client *http.Client) {
+	m.baselines = baselinesFromProbes(probeCalibration(baseURL, client))
+}
+
+// probeCalibration requests calibrationProbes bogus paths and returns their soft
+// (non-hard-404) response shapes. paths grow in length (see calibrationSuffix) so a
+// path-reflecting catch-all is detectable. deterministic: paths come from the index.
+func probeCalibration(baseURL string, client *http.Client) []responseMeta {
+	probes := make([]responseMeta, 0, calibrationProbes)
 	for i := 0; i < calibrationProbes; i++ {
-		probe := baseURL + calibrationPrefix + strconv.Itoa(i)
+		probe := baseURL + calibrationPrefix + calibrationSuffix(i)
 		req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, probe, http.NoBody)
 		if err != nil {
 			charmlog.Debugf("dirlist: build calibration request: %v", err)
@@ -355,17 +374,52 @@ func calibrate(m *matcher, baseURL string, client *http.Client) {
 		if meta.status == statusNotFound {
 			continue
 		}
-		if !containsBaseline(m.baselines, meta) {
-			m.baselines = append(m.baselines, meta)
-		}
+		probes = append(probes, meta)
 	}
+	return probes
 }
 
-// containsBaseline reports whether the shape is already recorded, so repeated
-// probes returning the same soft-404 don't bloat the baseline set.
+// calibrationSuffix returns the i-th probe suffix. each suffix is unique and longer
+// than the last, so a path-reflecting catch-all returns a different size per probe.
+func calibrationSuffix(i int) string {
+	return strconv.Itoa(i) + strings.Repeat("a", i*calibrationPadStep)
+}
+
+// baselinesFromProbes reduces raw calibration responses to the soft-404 shapes to
+// suppress. probes sharing a status and word count but differing in size are a
+// reflecting (or size-unstable) catch-all, so they collapse to one word-count-tolerant
+// baseline (size anySize); any other distinct shape is kept exact.
+func baselinesFromProbes(probes []responseMeta) []responseMeta {
+	type shapeKey struct{ status, words int }
+	order := make([]shapeKey, 0, len(probes))
+	sizes := make(map[shapeKey]map[int]struct{})
+	for _, p := range probes {
+		k := shapeKey{p.status, p.words}
+		if sizes[k] == nil {
+			sizes[k] = make(map[int]struct{})
+			order = append(order, k)
+		}
+		sizes[k][p.size] = struct{}{}
+	}
+
+	baselines := make([]responseMeta, 0, len(order))
+	for _, k := range order {
+		size := anySize
+		if len(sizes[k]) == 1 {
+			// one stable size for this status/words: keep exact-shape matching.
+			for s := range sizes[k] {
+				size = s
+			}
+		}
+		baselines = append(baselines, responseMeta{status: k.status, size: size, words: k.words})
+	}
+	return baselines
+}
+
+// containsBaseline reports whether meta matches any calibrated soft-404 baseline.
 func containsBaseline(baselines []responseMeta, meta responseMeta) bool {
 	for i := 0; i < len(baselines); i++ {
-		if baselines[i] == meta {
+		if baselines[i].matchesBaseline(meta) {
 			return true
 		}
 	}

--- a/internal/scan/dirlist_test.go
+++ b/internal/scan/dirlist_test.go
@@ -358,3 +358,116 @@ func has(set map[string]struct{}, key string) bool {
 	_, ok := set[key]
 	return ok
 }
+
+// reflectingWildcardApp serves a catch-all whose body echoes the request path, so
+// its size tracks path length; /admin returns a distinct real page.
+func reflectingWildcardApp() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("<html><body>admin control panel dashboard credentials</body></html>"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/admin" {
+			return
+		}
+		w.Write([]byte("<html><body>page not found: " + r.URL.Path + "</body></html>"))
+	})
+	return httptest.NewServer(mux)
+}
+
+// a reflecting catch-all hands each path a different size, so exact-shape calibration
+// misses it; the varied probe lengths expose it and -ac suppresses the bogus paths.
+func TestDirlist_CalibrationSuppressesReflectingWildcard(t *testing.T) {
+	srv := reflectingWildcardApp()
+	defer srv.Close()
+
+	dir := t.TempDir()
+	wordlist := filepath.Join(dir, "words.txt")
+	if err := os.WriteFile(wordlist, []byte("admin\nnope\nbogus\nmissing\n"), 0o600); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+
+	results, err := Dirlist("small", srv.URL, 5*time.Second, 3, "", DirlistOptions{
+		Wordlist:  wordlist,
+		Calibrate: true,
+	})
+	if err != nil {
+		t.Fatalf("Dirlist (-ac): %v", err)
+	}
+
+	got := pathSet(results)
+	if !has(got, "/admin") {
+		t.Errorf("real /admin must still surface, got %v", sortedKeys(got))
+	}
+	for _, bogus := range []string{"/nope", "/bogus", "/missing"} {
+		if has(got, bogus) {
+			t.Errorf("reflecting soft-404 %s should be suppressed by -ac, got %v", bogus, sortedKeys(got))
+		}
+	}
+}
+
+func TestBaselinesFromProbes(t *testing.T) {
+	tests := []struct {
+		name   string
+		probes []responseMeta
+		want   []responseMeta
+	}{
+		{
+			name:   "stable catch-all keeps exact shape",
+			probes: []responseMeta{{status: 200, size: 63, words: 7}, {status: 200, size: 63, words: 7}},
+			want:   []responseMeta{{status: 200, size: 63, words: 7}},
+		},
+		{
+			name:   "reflecting catch-all collapses to words-tolerant",
+			probes: []responseMeta{{status: 200, size: 40, words: 4}, {status: 200, size: 48, words: 4}, {status: 200, size: 56, words: 4}},
+			want:   []responseMeta{{status: 200, size: anySize, words: 4}},
+		},
+		{
+			name:   "distinct shapes kept separately",
+			probes: []responseMeta{{status: 200, size: 40, words: 4}, {status: 301, size: 0, words: 0}},
+			want:   []responseMeta{{status: 200, size: 40, words: 4}, {status: 301, size: 0, words: 0}},
+		},
+		{
+			name:   "no probes yields no baseline",
+			probes: nil,
+			want:   []responseMeta{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := baselinesFromProbes(tt.probes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("baselinesFromProbes(%v) = %v, want %v", tt.probes, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesBaseline_AnySize(t *testing.T) {
+	tolerant := responseMeta{status: 200, size: anySize, words: 4}
+	if !tolerant.matchesBaseline(responseMeta{status: 200, size: 999, words: 4}) {
+		t.Error("anySize baseline should match any size with the same status/words")
+	}
+	if tolerant.matchesBaseline(responseMeta{status: 200, size: 999, words: 5}) {
+		t.Error("anySize baseline must still discriminate on word count")
+	}
+	exact := responseMeta{status: 200, size: 42, words: 5}
+	if exact.matchesBaseline(responseMeta{status: 200, size: 43, words: 5}) {
+		t.Error("exact baseline should not match a different size")
+	}
+}
+
+func TestCalibrationSuffix_UniqueAndGrowing(t *testing.T) {
+	prev := -1
+	seen := make(map[string]struct{})
+	for i := 0; i < calibrationProbes; i++ {
+		s := calibrationSuffix(i)
+		if _, dup := seen[s]; dup {
+			t.Errorf("suffix %q repeats across probes", s)
+		}
+		seen[s] = struct{}{}
+		if len(s) <= prev {
+			t.Errorf("suffix %d %q length %d not greater than previous %d", i, s, len(s), prev)
+		}
+		prev = len(s)
+	}
+}


### PR DESCRIPTION
the -ac soft-404 baseline matched responses on an exact status/size/words tuple, and the calibration probes were all the same length. a catch-all that echoes the request path answers every path with a different size, so the baseline matched none of the real probe paths and the wildcard leaked.

grow the probe lengths so a reflecting catch-all yields a different size per probe, and when probes share a status and word count but differ in size, record a word-count-tolerant baseline instead of an exact one. stable catch-alls return one shape and keep exact matching, so non-reflecting targets are unchanged. verified live: vercel (200) and a stackoverflow waf (403) reflect the path and are now suppressed under -ac.