### PR TITLE
fix(scan): apply reflected-path tolerance to db panel calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sif has a modular architecture. modules are defined in yaml and can be extended 
 | `-fs` | dirlist: filter out responses of these body sizes (comma list) |
 | `-fw` | dirlist: filter out responses with these word counts (comma list) |
 | `-fr` | dirlist: filter out responses whose body matches this regex |
-| `-ac` | dirlist: auto-calibrate the soft-404 wildcard baseline |
+| `-ac` | auto-calibrate the soft-404 wildcard baseline (dirlist, sql) |
 | `-w` | dirlist: custom wordlist (local file or url; overrides `-dirlist` size) |
 | `-e` | dirlist: extensions appended to each word (comma list, e.g. php,bak,env) |
 | `-dnslist` | subdomain enumeration (small/medium/large) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ type Settings struct {
 	DirFilterSizes    string // -fs dirlist: body sizes to drop
 	DirFilterWords    string // -fw dirlist: word counts to drop
 	DirFilterRegex    string // -fr dirlist: regex; body match drops response
-	DirCalibrate      bool   // -ac dirlist: auto-calibrate soft-404 baseline
+	Calibrate         bool   // -ac auto-calibrate the soft-404 baseline (dirlist, sql)
 	DirWordlist       string // -w  dirlist: custom wordlist (file path or url)
 	DirExtensions     string // -e  dirlist: extensions appended to each word
 	Dnslist           string
@@ -131,7 +131,7 @@ func registerFlags(settings *Settings) *goflags.FlagSet {
 		flagSet.StringVar(&settings.DirFilterSizes, "fs", "", "Dirlist: filter out responses of these body sizes (comma list)"),
 		flagSet.StringVar(&settings.DirFilterWords, "fw", "", "Dirlist: filter out responses with these word counts (comma list)"),
 		flagSet.StringVar(&settings.DirFilterRegex, "fr", "", "Dirlist: filter out responses whose body matches this regex"),
-		flagSet.BoolVar(&settings.DirCalibrate, "ac", false, "Dirlist: auto-calibrate the soft-404 wildcard baseline"),
+		flagSet.BoolVar(&settings.Calibrate, "ac", false, "Auto-calibrate the soft-404 wildcard baseline (dirlist, sql)"),
 		flagSet.StringVar(&settings.DirWordlist, "w", "", "Dirlist: custom wordlist (local file path or url; overrides -dirlist size)"),
 		flagSet.StringVar(&settings.DirExtensions, "e", "", "Dirlist: extensions appended to each word (comma list, e.g. php,bak,env)"),
 		flagSet.EnumVar(&settings.Dnslist, "dnslist", Nil, "DNS fuzzing scan size (small/medium/large)", listSizes),

--- a/internal/scan/dirlist.go
+++ b/internal/scan/dirlist.go
@@ -50,8 +50,9 @@ const dirlistBodyCap = 512 * 1024
 // cannot exist, then treat any response shape they share as the wildcard
 // baseline. deterministic (no rng) so the workflow stays reproducible.
 const (
-	calibrationProbes = 3
-	calibrationPrefix = "/sif-cal-"
+	calibrationProbes  = 3
+	calibrationPrefix  = "/sif-cal-"
+	calibrationPadStep = 8 // per-probe suffix growth; see calibrationSuffix
 )
 
 // statusNotFound / statusForbidden are the historical default "not interesting"
@@ -88,6 +89,20 @@ type responseMeta struct {
 	status int
 	size   int
 	words  int
+}
+
+// anySize, as a baseline size, marks a catch-all whose body size is unreliable (it
+// reflects the request path), so the baseline matches on status and word count alone.
+const anySize = -1
+
+// matchesBaseline reports whether meta looks like the calibrated soft-404 shape b.
+// a normal baseline compares status, size and words exactly; a reflecting catch-all
+// (b.size == anySize) compares status and words only, since its size is not stable.
+func (b responseMeta) matchesBaseline(meta responseMeta) bool {
+	if b.status != meta.status || b.words != meta.words {
+		return false
+	}
+	return b.size == anySize || b.size == meta.size
 }
 
 // matcher decides whether a response is "interesting" using the same precedence
@@ -154,13 +169,10 @@ func newMatcher(opts *DirlistOptions) (*matcher, error) {
 // over matches: a calibrated baseline, an -fc/-fs/-fw hit, or an -fr body match
 // always drops the response; otherwise the -mc set (when set) gates it.
 func (m *matcher) Matches(meta responseMeta, body []byte) bool {
-	// a calibrated soft-404 shape is the same response the catch-all hands every
-	// bogus path, so drop anything that matches a baseline exactly.
-	for i := 0; i < len(m.baselines); i++ {
-		b := m.baselines[i]
-		if b.status == meta.status && b.size == meta.size && b.words == meta.words {
-			return false
-		}
+	// a calibrated soft-404 shape is the response the catch-all hands every bogus
+	// path, so drop anything matching a baseline.
+	if containsBaseline(m.baselines, meta) {
+		return false
 	}
 
 	if _, drop := m.filterCodes[meta.status]; drop {
@@ -342,11 +354,18 @@ func scanLines(r io.Reader) ([]string, error) {
 
 // calibrate probes a few paths that cannot exist and records the response shapes
 // the catch-all hands them. those baselines feed the matcher so a soft-404 200
-// (the SPA wildcard) is suppressed before the real run. deterministic by design:
-// the probe paths come from the loop index, never a random source.
+// (the SPA wildcard) is suppressed before the real run.
 func calibrate(m *matcher, baseURL string, client *http.Client) {
+	m.baselines = baselinesFromProbes(probeCalibration(baseURL, client))
+}
+
+// probeCalibration requests calibrationProbes bogus paths and returns their soft
+// (non-hard-404) response shapes. paths grow in length (see calibrationSuffix) so a
+// path-reflecting catch-all is detectable. deterministic: paths come from the index.
+func probeCalibration(baseURL string, client *http.Client) []responseMeta {
+	probes := make([]responseMeta, 0, calibrationProbes)
 	for i := 0; i < calibrationProbes; i++ {
-		probe := baseURL + calibrationPrefix + strconv.Itoa(i)
+		probe := baseURL + calibrationPrefix + calibrationSuffix(i)
 		req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, probe, http.NoBody)
 		if err != nil {
 			charmlog.Debugf("dirlist: build calibration request: %v", err)
@@ -365,17 +384,51 @@ func calibrate(m *matcher, baseURL string, client *http.Client) {
 		if meta.status == statusNotFound {
 			continue
 		}
-		if !containsBaseline(m.baselines, meta) {
-			m.baselines = append(m.baselines, meta)
-		}
+		probes = append(probes, meta)
 	}
+	return probes
 }
 
-// containsBaseline reports whether the shape is already recorded, so repeated
-// probes returning the same soft-404 don't bloat the baseline set.
+// calibrationSuffix returns the i-th probe suffix. each suffix is unique and longer
+// than the last, so a path-reflecting catch-all returns a different size per probe.
+func calibrationSuffix(i int) string {
+	return strconv.Itoa(i) + strings.Repeat("a", i*calibrationPadStep)
+}
+
+// baselinesFromProbes reduces raw calibration responses to the soft-404 shapes to
+// suppress. probes sharing status/word-count but differing in size are a reflecting
+// catch-all, collapsed to one word-count-tolerant baseline (size anySize); others exact.
+func baselinesFromProbes(probes []responseMeta) []responseMeta {
+	type shapeKey struct{ status, words int }
+	order := make([]shapeKey, 0, len(probes))
+	sizes := make(map[shapeKey]map[int]struct{})
+	for _, p := range probes {
+		k := shapeKey{p.status, p.words}
+		if sizes[k] == nil {
+			sizes[k] = make(map[int]struct{})
+			order = append(order, k)
+		}
+		sizes[k][p.size] = struct{}{}
+	}
+
+	baselines := make([]responseMeta, 0, len(order))
+	for _, k := range order {
+		size := anySize
+		if len(sizes[k]) == 1 {
+			// one stable size for this status/words: keep exact-shape matching.
+			for s := range sizes[k] {
+				size = s
+			}
+		}
+		baselines = append(baselines, responseMeta{status: k.status, size: size, words: k.words})
+	}
+	return baselines
+}
+
+// containsBaseline reports whether meta matches any calibrated soft-404 baseline.
 func containsBaseline(baselines []responseMeta, meta responseMeta) bool {
 	for i := 0; i < len(baselines); i++ {
-		if baselines[i] == meta {
+		if baselines[i].matchesBaseline(meta) {
 			return true
 		}
 	}

--- a/internal/scan/dirlist_test.go
+++ b/internal/scan/dirlist_test.go
@@ -381,3 +381,116 @@ func TestScanLinesErrorsOnOverlongLine(t *testing.T) {
 		t.Fatalf("scanLines err = %v, want bufio.ErrTooLong", err)
 	}
 }
+
+// reflectingWildcardApp serves a catch-all whose body echoes the request path, so
+// its size tracks path length; /admin returns a distinct real page.
+func reflectingWildcardApp() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/admin", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("<html><body>admin control panel dashboard credentials</body></html>"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/admin" {
+			return
+		}
+		w.Write([]byte("<html><body>page not found: " + r.URL.Path + "</body></html>"))
+	})
+	return httptest.NewServer(mux)
+}
+
+// a reflecting catch-all hands each path a different size, so exact-shape calibration
+// misses it; the varied probe lengths expose it and -ac suppresses the bogus paths.
+func TestDirlist_CalibrationSuppressesReflectingWildcard(t *testing.T) {
+	srv := reflectingWildcardApp()
+	defer srv.Close()
+
+	dir := t.TempDir()
+	wordlist := filepath.Join(dir, "words.txt")
+	if err := os.WriteFile(wordlist, []byte("admin\nnope\nbogus\nmissing\n"), 0o600); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+
+	results, err := Dirlist("small", srv.URL, 5*time.Second, 3, "", DirlistOptions{
+		Wordlist:  wordlist,
+		Calibrate: true,
+	})
+	if err != nil {
+		t.Fatalf("Dirlist (-ac): %v", err)
+	}
+
+	got := pathSet(results)
+	if !has(got, "/admin") {
+		t.Errorf("real /admin must still surface, got %v", sortedKeys(got))
+	}
+	for _, bogus := range []string{"/nope", "/bogus", "/missing"} {
+		if has(got, bogus) {
+			t.Errorf("reflecting soft-404 %s should be suppressed by -ac, got %v", bogus, sortedKeys(got))
+		}
+	}
+}
+
+func TestBaselinesFromProbes(t *testing.T) {
+	tests := []struct {
+		name   string
+		probes []responseMeta
+		want   []responseMeta
+	}{
+		{
+			name:   "stable catch-all keeps exact shape",
+			probes: []responseMeta{{status: 200, size: 63, words: 7}, {status: 200, size: 63, words: 7}},
+			want:   []responseMeta{{status: 200, size: 63, words: 7}},
+		},
+		{
+			name:   "reflecting catch-all collapses to words-tolerant",
+			probes: []responseMeta{{status: 200, size: 40, words: 4}, {status: 200, size: 48, words: 4}, {status: 200, size: 56, words: 4}},
+			want:   []responseMeta{{status: 200, size: anySize, words: 4}},
+		},
+		{
+			name:   "distinct shapes kept separately",
+			probes: []responseMeta{{status: 200, size: 40, words: 4}, {status: 301, size: 0, words: 0}},
+			want:   []responseMeta{{status: 200, size: 40, words: 4}, {status: 301, size: 0, words: 0}},
+		},
+		{
+			name:   "no probes yields no baseline",
+			probes: nil,
+			want:   []responseMeta{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := baselinesFromProbes(tt.probes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("baselinesFromProbes(%v) = %v, want %v", tt.probes, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesBaseline_AnySize(t *testing.T) {
+	tolerant := responseMeta{status: 200, size: anySize, words: 4}
+	if !tolerant.matchesBaseline(responseMeta{status: 200, size: 999, words: 4}) {
+		t.Error("anySize baseline should match any size with the same status/words")
+	}
+	if tolerant.matchesBaseline(responseMeta{status: 200, size: 999, words: 5}) {
+		t.Error("anySize baseline must still discriminate on word count")
+	}
+	exact := responseMeta{status: 200, size: 42, words: 5}
+	if exact.matchesBaseline(responseMeta{status: 200, size: 43, words: 5}) {
+		t.Error("exact baseline should not match a different size")
+	}
+}
+
+func TestCalibrationSuffix_UniqueAndGrowing(t *testing.T) {
+	prev := -1
+	seen := make(map[string]struct{})
+	for i := 0; i < calibrationProbes; i++ {
+		s := calibrationSuffix(i)
+		if _, dup := seen[s]; dup {
+			t.Errorf("suffix %q repeats across probes", s)
+		}
+		seen[s] = struct{}{}
+		if len(s) <= prev {
+			t.Errorf("suffix %d %q length %d not greater than previous %d", i, s, len(s), prev)
+		}
+		prev = len(s)
+	}
+}

--- a/internal/scan/sql.go
+++ b/internal/scan/sql.go
@@ -115,7 +115,7 @@ var databaseErrorPatterns = []struct {
 }
 
 // SQL performs SQL reconnaissance on the target URL
-func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*SQLResult, error) {
+func SQL(targetURL string, timeout time.Duration, threads int, logdir string, calibrate bool) (*SQLResult, error) {
 	log := output.Module("SQL")
 	log.Start()
 
@@ -149,6 +149,17 @@ func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*
 		return nil
 	}
 
+	// a catch-all answering 200/403/401 for every path makes each probe look like a
+	// hit. with -ac, calibrate the soft-404 wildcard shape first (as dirlist does) and
+	// drop matching probes before isAdminPanel; off by default, so every hit is reported.
+	var baselines []responseMeta
+	if calibrate {
+		baselines = calibrateSQLBaseline(targetURL, client)
+		if len(baselines) > 0 {
+			log.Info("calibrated %d soft-404 baseline(s)", len(baselines))
+		}
+	}
+
 	// check for admin panels
 	wg.Add(threads)
 	adminPathsChan := make(chan int, len(sqlAdminPaths))
@@ -178,9 +189,12 @@ func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*
 				// check for successful response (not 404)
 				if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
 					// read body to check for common admin panel indicators
-					body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*100)) // limit to 100KB
+					meta, body := readMeta(resp)
 					resp.Body.Close()
-					if err != nil {
+
+					// a catch-all hands the same shape to every path; drop it so a
+					// wildcard 200/403/401 is not reported as an admin panel.
+					if containsBaseline(baselines, meta) {
 						continue
 					}
 					bodyStr := string(body)
@@ -254,6 +268,34 @@ func SQL(targetURL string, timeout time.Duration, threads int, logdir string) (*
 
 	log.Complete(totalFindings, "found")
 	return result, nil
+}
+
+// calibrateSQLBaseline probes paths that cannot exist and records the soft-404
+// shapes a catch-all returns, so wildcard 200/403/401 pages are suppressed before
+// isAdminPanel runs. it shares dirlist's reflection-tolerant derivation.
+func calibrateSQLBaseline(targetURL string, client *http.Client) []responseMeta {
+	base := strings.TrimSuffix(targetURL, "/")
+	probes := make([]responseMeta, 0, calibrationProbes)
+	for i := 0; i < calibrationProbes; i++ {
+		probe := base + calibrationPrefix + calibrationSuffix(i) + "/"
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, probe, http.NoBody)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		meta, _ := readMeta(resp)
+		resp.Body.Close()
+		// a hard 404 is already filtered by status; only soft 200/403/401 shapes
+		// need a baseline to suppress them.
+		if meta.status == statusNotFound {
+			continue
+		}
+		probes = append(probes, meta)
+	}
+	return baselinesFromProbes(probes)
 }
 
 func isAdminPanel(body string, panelType string) bool {

--- a/internal/scan/sql_adminpanel_query_test.go
+++ b/internal/scan/sql_adminpanel_query_test.go
@@ -111,7 +111,7 @@ func TestSQL_JQueryCatchAllNotReported(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	result, err := SQL(srv.URL, 5*time.Second, 4, "")
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", false)
 	if err != nil {
 		t.Fatalf("SQL: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestSQL_RealPhpMyAdminReported(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	result, err := SQL(srv.URL, 5*time.Second, 4, "")
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", false)
 	if err != nil {
 		t.Fatalf("SQL: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestSQL_RealGenericPanelReported(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	result, err := SQL(srv.URL, 5*time.Second, 4, "")
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", false)
 	if err != nil {
 		t.Fatalf("SQL: %v", err)
 	}

--- a/internal/scan/sql_soft404_test.go
+++ b/internal/scan/sql_soft404_test.go
@@ -1,0 +1,248 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// representative bodies, not padded to force a size delta: a generic homepage and a
+// real admin login just have different content, hence different shapes. the catch-all
+// body carries no db keyword, so the comparison turns on the baseline, not isAdminPanel.
+const (
+	catchAllHome = `<!DOCTYPE html><html><head><title>Acme</title></head>` +
+		`<body><nav>Home About Contact</nav><main>Welcome to Acme.</main></body></html>`
+
+	realPMALogin = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">` +
+		`<title>phpMyAdmin</title><link rel="stylesheet" href="phpmyadmin.css.php"></head>` +
+		`<body class="loginform"><form method="post" action="index.php"><fieldset>` +
+		`<legend>Log in to phpMyAdmin</legend>` +
+		`<label>Username</label><input type="text" name="pma_username">` +
+		`<label>Password</label><input type="password" name="pma_password">` +
+		`<input type="submit" value="Go"></fieldset></form></body></html>`
+
+	realDBAdmin = `<!DOCTYPE html><html><head><title>Database Manager</title></head>` +
+		`<body><h1>MySQL Server 8.0</h1><table><tr><th>Database</th><th>Tables</th></tr>` +
+		`<tr><td>app_production</td><td>42</td></tr></table>` +
+		`<form action="/run"><textarea name="sql">SELECT 1</textarea><button>Run</button></form>` +
+		`</body></html>`
+)
+
+// countAdminPanels is nil-safe: SQL returns a nil result when nothing is found.
+func countAdminPanels(r *SQLResult) int {
+	if r == nil {
+		return 0
+	}
+	return len(r.AdminPanels)
+}
+
+// hasPanelType reports whether a panel of the given type was found.
+func hasPanelType(r *SQLResult, panelType string) bool {
+	if r == nil {
+		return false
+	}
+	for _, p := range r.AdminPanels {
+		if p.Type == panelType {
+			return true
+		}
+	}
+	return false
+}
+
+// a 200 catch-all (the SPA wildcard) is calibrated as a baseline shape.
+func TestCalibrateSQLBaseline_CatchAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(catchAllHome))
+	}))
+	defer srv.Close()
+
+	baselines := calibrateSQLBaseline(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	if len(baselines) == 0 {
+		t.Fatal("a 200 catch-all should produce at least one baseline shape")
+	}
+}
+
+// a server that hard-404s every bogus path needs no baseline (status already filters).
+func TestCalibrateSQLBaseline_HardNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	baselines := calibrateSQLBaseline(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	if len(baselines) != 0 {
+		t.Errorf("hard-404 server should yield no baseline, got %d", len(baselines))
+	}
+}
+
+// with -ac on, a 200 catch-all serving a db-topical page at every path yields no
+// admin-panel finding once the wildcard shape is calibrated.
+func TestSQL_CatchAllSuppressed(t *testing.T) {
+	page := "<html><body>database dashboard for our service</body></html>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if n := countAdminPanels(result); n != 0 {
+		t.Errorf("catch-all produced %d admin-panel finding(s) with -ac, want 0", n)
+	}
+}
+
+// a 403 WAF that blanket-blocks with a db-mentioning page is also a catch-all and
+// must be suppressed (covers the 403 branch of the status set).
+func TestSQL_403WAFCatchAllSuppressed(t *testing.T) {
+	page := "Request blocked: possible sql injection attempt detected"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if n := countAdminPanels(result); n != 0 {
+		t.Errorf("403 WAF catch-all produced %d admin-panel finding(s) with -ac, want 0", n)
+	}
+}
+
+// suppression is opt-in: with -ac off (the default) the same catch-all is still
+// reported, matching dirlist's behavior.
+func TestSQL_CalibrateDisabledStillReports(t *testing.T) {
+	page := "<html><body>database dashboard for our service</body></html>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", false)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if countAdminPanels(result) == 0 {
+		t.Error("with -ac off, the catch-all should still be reported (suppression is opt-in)")
+	}
+}
+
+// a real phpMyAdmin hosted on a catch-all is still reported under -ac: a genuine
+// login page is a different shape than the wildcard homepage, so it is not dropped.
+func TestSQL_RealPanelAmongCatchAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/phpmyadmin/" {
+			_, _ = w.Write([]byte(realPMALogin))
+			return
+		}
+		_, _ = w.Write([]byte(catchAllHome))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if !hasPanelType(result, "phpMyAdmin") {
+		t.Errorf("real phpMyAdmin on a catch-all should still be reported; panels=%d",
+			countAdminPanels(result))
+	}
+}
+
+// a real generic interface (a distinct db admin page at /db/) is still reported
+// under -ac, so calibration does not over-suppress genuine findings.
+func TestSQL_RealGenericPanelAmongCatchAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/db/" {
+			_, _ = w.Write([]byte(realDBAdmin))
+			return
+		}
+		_, _ = w.Write([]byte(catchAllHome))
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if countAdminPanels(result) == 0 {
+		t.Error("a real database interface at /db/ on a catch-all should still be reported")
+	}
+}
+
+// the normal case (no catch-all): a host that 404s everything except a real
+// phpMyAdmin still reports it, since calibration finds no baseline.
+func TestSQL_HardNotFoundRealPanelReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/phpmyadmin/" {
+			_, _ = w.Write([]byte(realPMALogin))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if !hasPanelType(result, "phpMyAdmin") {
+		t.Error("phpMyAdmin on a non-catch-all host should be reported")
+	}
+}
+
+// a catch-all that reflects the request path varies its size per path; the shared
+// reflection-tolerant calibration suppresses it under -ac.
+func TestSQL_ReflectedPathCatchAllSuppressed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "<html><body>no such page: %s (database)</body></html>", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if n := countAdminPanels(result); n != 0 {
+		t.Errorf("reflected-path catch-all should be suppressed under -ac, got %d panel(s)", n)
+	}
+}
+
+// the word-count-tolerant baseline must not nuke real findings: a genuine phpMyAdmin
+// hosted behind a reflecting catch-all has a distinct word count, so it still surfaces.
+func TestSQL_ReflectingCatchAllRealPanelStillReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/phpmyadmin/" {
+			_, _ = w.Write([]byte(realPMALogin))
+			return
+		}
+		fmt.Fprintf(w, "<html><body>no such page: %s (database)</body></html>", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	result, err := SQL(srv.URL, 5*time.Second, 4, "", true)
+	if err != nil {
+		t.Fatalf("SQL: %v", err)
+	}
+	if !hasPanelType(result, "phpMyAdmin") {
+		t.Errorf("real phpMyAdmin on a reflecting catch-all should still surface; panels=%d",
+			countAdminPanels(result))
+	}
+}

--- a/sif.go
+++ b/sif.go
@@ -354,7 +354,7 @@ func (app *App) Run() error {
 				FilterSizes: app.settings.DirFilterSizes,
 				FilterWords: app.settings.DirFilterWords,
 				FilterRegex: app.settings.DirFilterRegex,
-				Calibrate:   app.settings.DirCalibrate,
+				Calibrate:   app.settings.Calibrate,
 				Wordlist:    app.settings.DirWordlist,
 				Extensions:  app.settings.DirExtensions,
 			})
@@ -498,7 +498,7 @@ func (app *App) Run() error {
 		}
 
 		if app.settings.SQL {
-			result, err := scan.SQL(url, app.settings.Timeout, app.settings.Threads, app.settings.LogDir)
+			result, err := scan.SQL(url, app.settings.Timeout, app.settings.Threads, app.settings.LogDir, app.settings.Calibrate)
 			if err != nil {
 				log.Errorf("Error while running SQL reconnaissance: %s", err)
 			} else if result != nil {


### PR DESCRIPTION
with `-ac`, the db-panel (sql admin-panel) scan now calibrates a soft-404 baseline the way
dirlist does, so a host that answers 200/403/401 for every path no longer leaks every generic
db path as a panel; real panels keep a distinct word count and still surface. three commits
build it up: dirlist's soft-404 calibration first learns to tolerate catch-alls that echo the
request path (their body size varies per probe, so the baseline compares status and word count
only), then the db-panel scan gains the same opt-in baseline, then its calibration is pointed
at dirlist's shared reflection-tolerant `baselinesFromProbes`.

build/vet/lint clean, `go test ./internal/scan/` green.
