### PR TITLE
fix(scan): scope passive ct-feed subdomains to the target

### DIFF
--- a/internal/scan/passive.go
+++ b/internal/scan/passive.go
@@ -141,7 +141,7 @@ func fetchCrtsh(ctx context.Context, client *http.Client, domain string) ([]stri
 	for i := 0; i < len(entries); i++ {
 		// name_value can pack several names separated by newlines.
 		for _, name := range strings.Split(entries[i].NameValue, "\n") {
-			if host := normalizeHost(name); host != "" {
+			if host := normalizeHost(name); host != "" && inDomain(host, domain) {
 				names = append(names, host)
 			}
 		}
@@ -164,7 +164,7 @@ func fetchCertspotter(ctx context.Context, client *http.Client, domain string) (
 	var names []string
 	for i := 0; i < len(entries); i++ {
 		for _, name := range entries[i].DNSNames {
-			if host := normalizeHost(name); host != "" {
+			if host := normalizeHost(name); host != "" && inDomain(host, domain) {
 				names = append(names, host)
 			}
 		}
@@ -224,12 +224,19 @@ func passiveGET(ctx context.Context, client *http.Client, reqURL string) ([]byte
 	return body, nil
 }
 
-// normalizeHost lowercases a name and strips a leading wildcard label so
-// "*.example.com" and "EXAMPLE.com" collapse to one canonical host.
+// normalizeHost lowercases a name and strips a leading wildcard label and a
+// trailing root dot so "*.example.com" and "example.com." collapse to one host.
 func normalizeHost(name string) string {
 	host := strings.ToLower(strings.TrimSpace(name))
 	host = strings.TrimPrefix(host, "*.")
+	host = strings.TrimSuffix(host, ".")
 	return host
+}
+
+// inDomain rejects off-scope names a shared/multi-SAN cert happens to list.
+func inDomain(host, domain string) bool {
+	domain = strings.ToLower(domain)
+	return host == domain || strings.HasSuffix(host, "."+domain)
 }
 
 // addAll inserts every value into the dedupe set.

--- a/internal/scan/passive_test.go
+++ b/internal/scan/passive_test.go
@@ -145,6 +145,29 @@ func TestPassive_ResultType(t *testing.T) {
 	}
 }
 
+func TestPassive_ScopesSubdomainsToTarget(t *testing.T) {
+	// notexample.com guards the suffix-match trap: not a subdomain of example.com.
+	const sharedCert = `[
+		{"name_value": "www.example.com\nshared.othersite.com"},
+		{"name_value": "notexample.com\n*.example.com"}
+	]`
+	fixtureServer(t, sharedCert, "[]", "")
+
+	result, err := Passive("https://example.com", 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("Passive: %v", err)
+	}
+
+	for _, off := range []string{"shared.othersite.com", "notexample.com"} {
+		if urlsContain(result.Subdomains, off) {
+			t.Errorf("off-scope name %q leaked as a subdomain: %v", off, result.Subdomains)
+		}
+	}
+	if !urlsContain(result.Subdomains, "www.example.com") {
+		t.Errorf("expected the in-scope subdomain to remain: %v", result.Subdomains)
+	}
+}
+
 func TestNormalizeHost(t *testing.T) {
 	tests := []struct {
 		in   string
@@ -152,6 +175,7 @@ func TestNormalizeHost(t *testing.T) {
 	}{
 		{"www.example.com", "www.example.com"},
 		{"*.example.com", "example.com"},
+		{"www.example.com.", "www.example.com"},
 		{"  WWW.Example.COM  ", "www.example.com"},
 		{"", ""},
 	}


### PR DESCRIPTION
shared/multi-SAN certificates list unrelated names, so collecting every crt.sh/certspotter
entry reported off-scope hosts as subdomains of the target. keep only the target or a subdomain
of it.

build/vet/lint clean, `go test ./internal/scan/` green.
