### PR TITLE
refactor(scan): extract favicon hashing into internal/fingerprint

### DIFF
--- a/internal/fingerprint/favicon.go
+++ b/internal/fingerprint/favicon.go
@@ -1,0 +1,56 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+// Package fingerprint holds small response-fingerprinting primitives shared by
+// the scan checks and the module engine, so both compute identical values.
+package fingerprint
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/twmb/murmur3"
+)
+
+// b64LineLen is python's base64.encodebytes line width. mmh3/shodan hash the
+// chunked base64 (newline every 76 chars, trailing newline), so we must wrap at
+// exactly this width to land on the same hash.
+const b64LineLen = 76
+
+// FaviconHash computes shodan's favicon hash: murmur3 32-bit over the python
+// base64.encodebytes encoding of the raw icon (newline every 76 chars plus a
+// trailing newline), reinterpreted as a signed int32 (both load-bearing, golden-pinned).
+func FaviconHash(data []byte) int32 {
+	encoded := encodeFaviconBase64(data)
+	return int32(murmur3.Sum32(encoded)) //nolint:gosec // shodan stores the signed reinterpretation on purpose
+}
+
+// encodeFaviconBase64 mirrors python's base64.encodebytes: standard base64 with
+// a newline inserted every 76 output characters and a trailing newline. this is
+// the exact byte stream shodan feeds to mmh3, so it must match byte-for-byte.
+func encodeFaviconBase64(data []byte) []byte {
+	raw := base64.StdEncoding.EncodeToString(data)
+
+	var b strings.Builder
+	// final size: the base64 body plus one '\n' per (full or partial) 76-char
+	// line. preallocate so the builder never regrows mid-loop.
+	b.Grow(len(raw) + len(raw)/b64LineLen + 1)
+	for i := 0; i < len(raw); i += b64LineLen {
+		end := i + b64LineLen
+		if end > len(raw) {
+			end = len(raw)
+		}
+		b.WriteString(raw[i:end])
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}

--- a/internal/fingerprint/favicon_test.go
+++ b/internal/fingerprint/favicon_test.go
@@ -1,0 +1,68 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package fingerprint
+
+import (
+	"strings"
+	"testing"
+)
+
+// goldenFaviconBytes is a fixed payload long enough to span multiple base64
+// lines, so the python-style 76-char chunking is actually exercised by the hash.
+var goldenFaviconBytes = []byte(strings.Repeat("sif-favicon-golden-test-bytes-", 8))
+
+// goldenFaviconHash is the pinned shodan mmh3 hash of goldenFaviconBytes: the python
+// base64.encodebytes byte stream (76-char lines + trailing newline) through murmur3-32,
+// reinterpreted as a signed int32. if the chunking or signedness regress, this test fails.
+const goldenFaviconHash int32 = -1554620260
+
+// goldenHelloHash pins a short single-line case so a regression in the trailing
+// newline (which the small case still has) is caught independently.
+const goldenHelloHash int32 = 1155597304
+
+func TestFaviconHashGolden(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want int32
+	}{
+		{name: "multi-line fixture", in: goldenFaviconBytes, want: goldenFaviconHash},
+		{name: "single-line hello", in: []byte("hello"), want: goldenHelloHash},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FaviconHash(tt.in); got != tt.want {
+				t.Errorf("FaviconHash = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFaviconBase64Chunking pins the encode step against python's
+// base64.encodebytes: a 60-byte input encodes to 80 base64 chars, so it must
+// wrap into two newline-terminated lines.
+func TestFaviconBase64Chunking(t *testing.T) {
+	in := []byte(strings.Repeat("A", 60))
+	got := string(encodeFaviconBase64(in))
+
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 wrapped lines, got %d: %q", len(lines), got)
+	}
+	if len(lines[0]) != b64LineLen {
+		t.Errorf("first line = %d chars, want %d", len(lines[0]), b64LineLen)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("encoding must end in a trailing newline, got %q", got)
+	}
+}

--- a/internal/scan/favicon.go
+++ b/internal/scan/favicon.go
@@ -14,7 +14,6 @@ package scan
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,10 +21,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dropalldatabases/sif/internal/fingerprint"
 	"github.com/dropalldatabases/sif/internal/httpx"
 	"github.com/dropalldatabases/sif/internal/logger"
 	"github.com/dropalldatabases/sif/internal/output"
-	"github.com/twmb/murmur3"
 )
 
 // FaviconResult is the computed shodan-style favicon hash plus the pivot query
@@ -41,11 +40,6 @@ type FaviconResult struct {
 // a megabyte ceiling covers oversized ones without letting a hostile endpoint
 // stream forever.
 const faviconBodyReadCap = 1 << 20
-
-// b64LineLen is python's base64.encodebytes line width. mmh3/shodan hash the
-// chunked base64 (newline every 76 chars, trailing newline), so we must wrap at
-// exactly this width to land on the same hash.
-const b64LineLen = 76
 
 // faviconLinkRegex pulls the href off a <link rel="...icon..."> tag so we can
 // fall back to a declared icon when /favicon.ico is absent.
@@ -95,7 +89,7 @@ func Favicon(targetURL string, timeout time.Duration, logdir string) (*FaviconRe
 		return nil, nil //nolint:nilnil // a missing favicon is not an error
 	}
 
-	hash := FaviconHash(data)
+	hash := fingerprint.FaviconHash(data)
 	result := &FaviconResult{
 		FaviconURL: iconURL,
 		Hash:       hash,
@@ -214,38 +208,6 @@ func resolveFaviconURL(base, href string) string {
 		return base + href
 	}
 	return base + "/" + href
-}
-
-// FaviconHash computes shodan's favicon hash: murmur3 32-bit over the python
-// base64.encodebytes encoding of the raw icon (newline every 76 chars plus a
-// trailing newline), reinterpreted as a signed int32. the chunking and the sign
-// are both load-bearing - shodan stores the value python's mmh3.hash() returns,
-// which is signed, over the wrapped base64, not the raw bytes. the golden test
-// pins this exactly.
-func FaviconHash(data []byte) int32 {
-	encoded := encodeFaviconBase64(data)
-	return int32(murmur3.Sum32(encoded)) //nolint:gosec // shodan stores the signed reinterpretation on purpose
-}
-
-// encodeFaviconBase64 mirrors python's base64.encodebytes: standard base64 with
-// a newline inserted every 76 output characters and a trailing newline. this is
-// the exact byte stream shodan feeds to mmh3, so it must match byte-for-byte.
-func encodeFaviconBase64(data []byte) []byte {
-	raw := base64.StdEncoding.EncodeToString(data)
-
-	var b strings.Builder
-	// final size: the base64 body plus one '\n' per (full or partial) 76-char
-	// line. preallocate so the builder never regrows mid-loop.
-	b.Grow(len(raw) + len(raw)/b64LineLen + 1)
-	for i := 0; i < len(raw); i += b64LineLen {
-		end := i + b64LineLen
-		if end > len(raw) {
-			end = len(raw)
-		}
-		b.WriteString(raw[i:end])
-		b.WriteByte('\n')
-	}
-	return []byte(b.String())
 }
 
 // ResultType identifies favicon findings for the result registry.

--- a/internal/scan/favicon_test.go
+++ b/internal/scan/favicon_test.go
@@ -31,48 +31,6 @@ var goldenFaviconBytes = []byte(strings.Repeat("sif-favicon-golden-test-bytes-",
 // signedness regress, this number changes and the test fails.
 const goldenFaviconHash int32 = -1554620260
 
-// goldenHelloHash pins a short single-line case so a regression in the trailing
-// newline (which the small case still has) is caught independently.
-const goldenHelloHash int32 = 1155597304
-
-func TestFaviconHash_Golden(t *testing.T) {
-	tests := []struct {
-		name string
-		in   []byte
-		want int32
-	}{
-		{name: "multi-line fixture", in: goldenFaviconBytes, want: goldenFaviconHash},
-		{name: "single-line hello", in: []byte("hello"), want: goldenHelloHash},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FaviconHash(tt.in)
-			if got != tt.want {
-				t.Errorf("FaviconHash = %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
-
-// TestFaviconBase64Chunking pins the encode step against python's
-// base64.encodebytes: a 50-byte input encodes to >76 base64 chars, so it must
-// wrap into two newline-terminated lines.
-func TestFaviconBase64Chunking(t *testing.T) {
-	in := []byte(strings.Repeat("A", 60)) // 60 bytes -> 80 base64 chars -> two lines
-	got := string(encodeFaviconBase64(in))
-
-	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 wrapped lines, got %d: %q", len(lines), got)
-	}
-	if len(lines[0]) != b64LineLen {
-		t.Errorf("first line = %d chars, want %d", len(lines[0]), b64LineLen)
-	}
-	if !strings.HasSuffix(got, "\n") {
-		t.Errorf("encoding must end in a trailing newline, got %q", got)
-	}
-}
-
 // fixtureFaviconServer serves the golden bytes at /favicon.ico.
 func fixtureFaviconServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
splits the shodan favicon hash out of `internal/scan` into a leaf package so the scan check and
the module engine can share one implementation instead of each carrying a copy. pure move, no
behavior change: scan's favicon tests still pass and the golden test moves with the code.

build/vet/lint clean, `go test ./internal/scan/ ./internal/fingerprint/` green.

follow-up that uses this package: #183 (favicon module matcher).
