### PR TITLE
feat(modules): add favicon hash matcher

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -223,6 +223,30 @@ matchers:
       - 1337
 ```
 
+### favicon matcher
+
+match the shodan-style mmh3 hash of the response body. point the module at a
+favicon and list the hashes of the tech you want to fingerprint.
+
+```yaml
+http:
+  paths:
+    - "{{BaseURL}}/favicon.ico"
+  matchers:
+    - type: status
+      status:
+        - 200
+    - type: favicon
+      hash:
+        - -235701012   # jenkins
+        - 1278322581   # grafana
+```
+
+the hash is shodan's `http.favicon.hash` value. paste it signed or unsigned;
+both 32-bit forms are accepted, so values from shodan or any favicon-hash tool
+drop in without conversion. pair it with a `status: 200` matcher so an error
+page served for `/favicon.ico` is not hashed. a finding fires when the body
+hashes to any listed value.
 ### combining matchers
 
 multiple matchers are combined with AND logic by default.

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -246,10 +246,16 @@ func executeHTTPRequest(ctx context.Context, client *http.Client, r *httpRequest
 	// Extract data
 	extracted := runExtractors(cfg.Extractors, resp, bodyStr)
 
+	// favicon-only matches fire on binary icon bytes; report the hash, not the body.
+	evidence := truncateEvidence(bodyStr)
+	if fav, ok := faviconEvidence(cfg.Matchers, bodyStr); ok {
+		evidence = fav
+	}
+
 	return Finding{
 		URL:       r.URL,
 		Severity:  severity,
-		Evidence:  truncateEvidence(bodyStr),
+		Evidence:  evidence,
 		Extracted: extracted,
 	}, true
 }
@@ -276,8 +282,6 @@ func checkMatchers(matchers []Matcher, resp *http.Response, body string) bool {
 
 // checkMatcher evaluates a single matcher.
 func checkMatcher(m *Matcher, resp *http.Response, body string) bool {
-	part := getPart(m.Part, resp, body)
-
 	switch m.Type {
 	case "status":
 		for _, status := range m.Status {
@@ -288,10 +292,13 @@ func checkMatcher(m *Matcher, resp *http.Response, body string) bool {
 		return false
 
 	case "word":
-		return checkWords(part, m.Words, m.Condition)
+		return checkWords(getPart(m.Part, resp, body), m.Words, m.Condition)
 
 	case "regex":
-		return checkRegex(part, m.Regex, m.Condition)
+		return checkRegex(getPart(m.Part, resp, body), m.Regex, m.Condition)
+
+	case "favicon":
+		return checkFaviconHash(body, m.Hash)
 
 	case "size":
 		// size matches the response body length against any listed value.

--- a/internal/modules/favicon.go
+++ b/internal/modules/favicon.go
@@ -1,0 +1,82 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/dropalldatabases/sif/internal/fingerprint"
+)
+
+// checkFaviconHash reports whether the body's shodan mmh3 hash matches any
+// configured value. only the body (the icon) is hashed; part is ignored.
+func checkFaviconHash(body string, want []int64) bool {
+	if len(want) == 0 {
+		return false
+	}
+	got := fingerprint.FaviconHash([]byte(body))
+	for _, w := range want {
+		if n, ok := normalizeFaviconHash(w); ok && n == got {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeFaviconHash folds a hash to the signed int32 shodan stores, accepting
+// either 32-bit form so a signed or unsigned value pastes in as-is. out-of-range
+// values are rejected so a stray number can't wrap into a false match.
+func normalizeFaviconHash(v int64) (int32, bool) {
+	if v < math.MinInt32 || v > math.MaxUint32 {
+		return 0, false
+	}
+	return int32(uint32(v)), true //nolint:gosec // intentional 32-bit fold to shodan's signed form
+}
+
+// faviconEvidence gives the hash as evidence for a favicon-only finding, and
+// nothing when a word/regex matcher is present so its body evidence stands.
+func faviconEvidence(matchers []Matcher, body string) (string, bool) {
+	favicon := false
+	for i := range matchers {
+		switch matchers[i].Type {
+		case "word", "regex":
+			return "", false
+		case "favicon":
+			favicon = true
+		}
+	}
+	if !favicon {
+		return "", false
+	}
+	return fmt.Sprintf("favicon mmh3=%d", fingerprint.FaviconHash([]byte(body))), true
+}
+
+// validateMatchers fails favicon matchers that would silently never fire (no
+// hash, or one out of 32-bit range) at load rather than at match time.
+func validateMatchers(matchers []Matcher) error {
+	for i := range matchers {
+		if matchers[i].Type != "favicon" {
+			continue
+		}
+		if len(matchers[i].Hash) == 0 {
+			return fmt.Errorf("favicon matcher requires at least one hash")
+		}
+		for _, h := range matchers[i].Hash {
+			if _, ok := normalizeFaviconHash(h); !ok {
+				return fmt.Errorf("favicon hash %d out of range (use a signed int32 or unsigned uint32 value)", h)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -1,0 +1,191 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dropalldatabases/sif/internal/fingerprint"
+	"github.com/dropalldatabases/sif/internal/httpx"
+)
+
+// faviconFixture hashes to a negative int32, so its signed and unsigned forms
+// differ and the unsigned-match case below actually exercises the fold.
+var faviconFixture = []byte(strings.Repeat("sif-favicon-golden-test-bytes-", 8))
+
+func TestCheckMatcherFavicon(t *testing.T) {
+	body := string(faviconFixture)
+	signed := int64(fingerprint.FaviconHash(faviconFixture))
+	if signed >= 0 {
+		t.Fatalf("fixture must hash to a negative int32 for the unsigned case to be meaningful, got %d", signed)
+	}
+	unsigned := int64(uint32(fingerprint.FaviconHash(faviconFixture)))
+
+	tests := []struct {
+		name   string
+		hashes []int64
+		expect bool
+	}{
+		{name: "signed match", hashes: []int64{signed}, expect: true},
+		{name: "unsigned match", hashes: []int64{unsigned}, expect: true},
+		{name: "one of many", hashes: []int64{1, 2, signed}, expect: true},
+		{name: "no match", hashes: []int64{1, 2, 3}, expect: false},
+		{name: "empty list", hashes: nil, expect: false},
+		{name: "out-of-range ignored", hashes: []int64{1 << 40}, expect: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Matcher{Type: "favicon", Hash: tt.hashes}
+			resp := fakeResponse(t, 200, nil)
+			if got := checkMatcher(m, resp, body); got != tt.expect {
+				t.Errorf("checkMatcher favicon = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestNormalizeFaviconHash(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     int64
+		want   int32
+		wantOK bool
+	}{
+		{name: "signed passthrough", in: -235701012, want: -235701012, wantOK: true},
+		{name: "unsigned folds to signed", in: 4059266284, want: -235701012, wantOK: true},
+		{name: "positive in range", in: 116323821, want: 116323821, wantOK: true},
+		{name: "min int32", in: math.MinInt32, want: math.MinInt32, wantOK: true},
+		{name: "max uint32 folds to -1", in: math.MaxUint32, want: -1, wantOK: true},
+		{name: "above uint32 rejected", in: math.MaxUint32 + 1, wantOK: false},
+		{name: "below int32 rejected", in: math.MinInt32 - 1, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeFaviconHash(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("normalizeFaviconHash(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFaviconEvidence(t *testing.T) {
+	body := string(faviconFixture)
+	hashLine := fmt.Sprintf("favicon mmh3=%d", fingerprint.FaviconHash(faviconFixture))
+	tests := []struct {
+		name     string
+		matchers []Matcher
+		want     string
+		wantOK   bool
+	}{
+		{name: "favicon only", matchers: []Matcher{{Type: "favicon"}}, want: hashLine, wantOK: true},
+		{name: "favicon with status", matchers: []Matcher{{Type: "status"}, {Type: "favicon"}}, want: hashLine, wantOK: true},
+		{name: "favicon with word keeps body", matchers: []Matcher{{Type: "word"}, {Type: "favicon"}}, wantOK: false},
+		{name: "favicon with regex keeps body", matchers: []Matcher{{Type: "regex"}, {Type: "favicon"}}, wantOK: false},
+		{name: "no favicon matcher", matchers: []Matcher{{Type: "status"}}, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := faviconEvidence(tt.matchers, body)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("evidence = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateMatchers(t *testing.T) {
+	tests := []struct {
+		name     string
+		matchers []Matcher
+		wantErr  bool
+	}{
+		{name: "valid signed", matchers: []Matcher{{Type: "favicon", Hash: []int64{-235701012}}}, wantErr: false},
+		{name: "valid unsigned", matchers: []Matcher{{Type: "favicon", Hash: []int64{4059266284}}}, wantErr: false},
+		{name: "favicon with no hash", matchers: []Matcher{{Type: "favicon"}}, wantErr: true},
+		{name: "out-of-range hash", matchers: []Matcher{{Type: "favicon", Hash: []int64{99999999999}}}, wantErr: true},
+		{name: "non-favicon ignored", matchers: []Matcher{{Type: "word", Words: []string{"x"}}}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateMatchers(tt.matchers); (err != nil) != tt.wantErr {
+				t.Errorf("validateMatchers err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// favicon composes with the negative flag like any other matcher.
+func TestCheckMatcherFaviconNegative(t *testing.T) {
+	signed := int64(fingerprint.FaviconHash(faviconFixture))
+	matchers := []Matcher{{Type: "favicon", Hash: []int64{signed}, Negative: true}}
+	resp := fakeResponse(t, 200, nil)
+	if checkMatchers(matchers, resp, string(faviconFixture)) {
+		t.Error("negative favicon matcher should not match its own hash")
+	}
+}
+
+// drives the full executor: fetch favicon, match on its hash, report the hash.
+func TestExecuteHTTPModuleFavicon(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			w.Header().Set("Content-Type", "image/x-icon")
+			_, _ = w.Write(faviconFixture)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// unsigned form must still match end to end
+	unsigned := int64(uint32(fingerprint.FaviconHash(faviconFixture)))
+	def := &YAMLModule{
+		ID:   "favicon-fp",
+		Type: TypeHTTP,
+		Info: YAMLModuleInfo{Severity: "info"},
+		HTTP: &HTTPConfig{
+			Method: "GET",
+			Paths:  []string{"{{BaseURL}}/favicon.ico"},
+			Matchers: []Matcher{
+				{Type: "status", Status: []int{200}},
+				{Type: "favicon", Hash: []int64{unsigned}},
+			},
+		},
+	}
+
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+	result, err := ExecuteHTTPModule(context.Background(), srv.URL, def, opts)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPModule: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(result.Findings))
+	}
+
+	wantEvidence := fmt.Sprintf("favicon mmh3=%d", fingerprint.FaviconHash(faviconFixture))
+	if got := result.Findings[0].Evidence; got != wantEvidence {
+		t.Errorf("evidence = %q, want %q", got, wantEvidence)
+	}
+}

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -86,12 +86,13 @@ type Finding struct {
 // Matcher defines matching logic for module responses.
 // Matchers are used to determine if a response indicates a vulnerability.
 type Matcher struct {
-	Type      string   `yaml:"type"` // regex, status, word, size
+	Type      string   `yaml:"type"` // regex, status, word, favicon
 	Part      string   `yaml:"part"` // body, header, all
 	Regex     []string `yaml:"regex,omitempty"`
 	Words     []string `yaml:"words,omitempty"`
 	Status    []int    `yaml:"status,omitempty"`
 	Size      []int    `yaml:"size,omitempty"`
+	Hash      []int64  `yaml:"hash,omitempty"` // favicon: shodan mmh3 hashes (signed or unsigned)
 	Condition string   `yaml:"condition"` // and, or
 	Negative  bool     `yaml:"negative"`
 }

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -105,6 +105,18 @@ func ParseYAMLModule(path string) (*YAMLModule, error) {
 			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
 		}
 	}
+	var matchers []Matcher
+	switch {
+	case ym.HTTP != nil:
+		matchers = ym.HTTP.Matchers
+	case ym.DNS != nil:
+		matchers = ym.DNS.Matchers
+	case ym.TCP != nil:
+		matchers = ym.TCP.Matchers
+	}
+	if err := validateMatchers(matchers); err != nil {
+		return nil, fmt.Errorf("module %q: %w", ym.ID, err)
+	}
 
 	return &ym, nil
 }


### PR DESCRIPTION
adds a favicon matcher to the yaml module engine: it matches the shodan-style mmh3 hash of the
response body, accepts the hash signed or unsigned, validates it at load so a bad value fails
loudly, and reports the hash (not raw icon bytes) as evidence for a favicon-only finding.
stacked on #182 (the first commit here is that fingerprint extraction); once it lands i'll
rebase this onto main so only the feat commit remains.

build/vet/lint clean, `go test ./internal/modules/` green (matcher, signed/unsigned normalize,
load validation, httptest end-to-end).
