### PR TITLE
feat(modules): add favicon fingerprint demo module

### DIFF
--- a/internal/scan/favicon_demo_sync_test.go
+++ b/internal/scan/favicon_demo_sync_test.go
@@ -1,0 +1,68 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package scan
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+// favicon demo modules must reference a hash from faviconHashes that names the
+// service in their filename, so a demo cannot drift from the scanner's map.
+func TestFaviconDemoModulesMatchCanonicalMap(t *testing.T) {
+	matches, err := filepath.Glob("../../modules/info/favicon-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) == 0 {
+		t.Skip("no favicon demo modules present")
+	}
+
+	for _, path := range matches {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			def, err := modules.ParseYAMLModule(path)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if def.HTTP == nil {
+				t.Fatal("favicon demo is not an http module")
+			}
+
+			var hashes []int64
+			for _, m := range def.HTTP.Matchers {
+				if m.Type == "favicon" {
+					hashes = append(hashes, m.Hash...)
+				}
+			}
+			if len(hashes) == 0 {
+				t.Fatal("no favicon hash in module")
+			}
+
+			service := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "favicon-"), ".yaml")
+			for _, h := range hashes {
+				// hashes are range-checked at parse, so int32(h) is the canonical fold.
+				tech, ok := faviconHashes[int32(h)]
+				if !ok {
+					t.Errorf("hash %d is absent from faviconHashes; demo references a hash the scanner does not know", h)
+					continue
+				}
+				if !strings.Contains(strings.ToLower(tech), service) {
+					t.Errorf("hash %d maps to %q, but the file names service %q", h, tech, service)
+				}
+			}
+		})
+	}
+}

--- a/modules/info/favicon-gitlab.yaml
+++ b/modules/info/favicon-gitlab.yaml
@@ -1,0 +1,23 @@
+# GitLab favicon fingerprint
+
+id: favicon-gitlab
+info:
+  name: GitLab Favicon Fingerprint
+  author: sif
+  severity: info
+  description: Detects GitLab by its default favicon hash
+  tags: [favicon, fingerprint, gitlab, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/favicon.ico"
+
+  matchers:
+    - type: status
+      status: [200]
+    - type: favicon
+      hash:
+        - -1255347784 # GitLab default favicon


### PR DESCRIPTION
stacked on #183 (and #182); until those land this pr's diff includes their commits, and i'll
rebase onto main once they merge so it reduces to the single demo commit.
`modules/info/favicon-gitlab.yaml` fingerprints gitlab by its default `/favicon.ico` hash using
the favicon matcher from #183, and `internal/scan/favicon_demo_sync_test.go` ties the demo hash
to the canonical `faviconHashes` map so the yaml cannot drift from the scanner's source of
truth. matches `/favicon.ico` default installs; instances that serve their icon from an
asset-pipeline path via `<link rel=icon>` are out of scope.

build/vet/lint clean, `go test ./internal/modules/ ./internal/scan/` green.
