### PR TITLE
feat(modules): add adminer and phpmyadmin database panel modules

### DIFF
--- a/internal/modules/db_panels_test.go
+++ b/internal/modules/db_panels_test.go
@@ -1,0 +1,88 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+func runDBModule(t *testing.T, file string, status int, headers map[string]string, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func dbExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestDBPanelModules(t *testing.T) {
+	const adminer = "../../modules/info/adminer-panel.yaml"
+	const phpmyadmin = "../../modules/info/phpmyadmin-panel.yaml"
+
+	adminerLogin := `<form action=""><input type="hidden" name="auth[driver]" value="server">` +
+		`<input name="auth[username]"></form>` +
+		`<p class="links"><a href="https://www.adminer.org/">Adminer</a> <span class="version">4.8.1</span></p>`
+	pmaLogin := `<link rel="stylesheet" href="themes/pmahomme/css/theme.css">` +
+		`<input type="text" name="pma_username"><script>var data = {"PMA_VERSION":"5.2.1"};</script>`
+
+	t.Run("adminer login", func(t *testing.T) {
+		res := runDBModule(t, adminer, 200, nil, adminerLogin)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an adminer finding")
+		}
+		if v := dbExtract(res, "adminer_version"); v != "4.8.1" {
+			t.Errorf("adminer_version=%q, want 4.8.1", v)
+		}
+	})
+
+	t.Run("adminer unrelated page", func(t *testing.T) {
+		if res := runDBModule(t, adminer, 200, nil, "<html><body>nothing</body></html>"); len(res.Findings) > 0 {
+			t.Errorf("unrelated page should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("phpmyadmin login", func(t *testing.T) {
+		res := runDBModule(t, phpmyadmin, 200, map[string]string{"Set-Cookie": "phpMyAdmin=abc123; path=/"}, pmaLogin)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a phpmyadmin finding")
+		}
+		if v := dbExtract(res, "phpmyadmin_version"); v != "5.2.1" {
+			t.Errorf("phpmyadmin_version=%q, want 5.2.1", v)
+		}
+	})
+
+	t.Run("phpmyadmin unrelated page", func(t *testing.T) {
+		if res := runDBModule(t, phpmyadmin, 200, nil, "<html><body>nothing</body></html>"); len(res.Findings) > 0 {
+			t.Errorf("unrelated page should not match, got %d findings", len(res.Findings))
+		}
+	})
+}

--- a/modules/info/adminer-panel.yaml
+++ b/modules/info/adminer-panel.yaml
@@ -1,0 +1,47 @@
+# Adminer Database Panel Detection Module
+
+id: adminer-panel
+info:
+  name: Adminer Database Panel
+  author: sif
+  severity: info
+  description: Detects exposed Adminer database management login panels
+  tags: [adminer, database, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/adminer.php"
+    - "{{BaseURL}}/adminer/"
+    - "{{BaseURL}}/adminer-4.8.1.php"
+    - "{{BaseURL}}/_adminer.php"
+    - "{{BaseURL}}/db/adminer.php"
+    - "{{BaseURL}}/adminer/adminer.php"
+
+  threads: 5
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: all
+      condition: or
+      words:
+        - 'name="auth[driver]"'
+        - 'name="auth[server]"'
+        - 'name="auth[username]"'
+        - 'name="auth[password]"'
+        - "www.adminer.org"
+
+  extractors:
+    - type: regex
+      name: adminer_version
+      part: body
+      regex:
+        - 'class="version">v?([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+        - 'Adminer[^0-9<]{0,40}([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+      group: 1

--- a/modules/info/phpmyadmin-panel.yaml
+++ b/modules/info/phpmyadmin-panel.yaml
@@ -1,0 +1,48 @@
+# phpMyAdmin Database Panel Detection Module
+
+id: phpmyadmin-panel
+info:
+  name: phpMyAdmin Database Panel
+  author: sif
+  severity: info
+  description: Detects exposed phpMyAdmin database management login panels
+  tags: [phpmyadmin, database, mysql, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/phpmyadmin/"
+    - "{{BaseURL}}/phpMyAdmin/"
+    - "{{BaseURL}}/pma/"
+    - "{{BaseURL}}/PMA/"
+    - "{{BaseURL}}/mysql/"
+    - "{{BaseURL}}/dbadmin/"
+    - "{{BaseURL}}/phpmyadmin/index.php"
+
+  threads: 5
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: all
+      condition: or
+      words:
+        - 'name="pma_username"'
+        - 'name="pma_password"'
+        - "pmahomme"
+        - 'content="phpMyAdmin"'
+        - "phpMyAdmin="
+
+  extractors:
+    - type: regex
+      name: phpmyadmin_version
+      part: all
+      regex:
+        - 'PMA_VERSION["'']?\s*[:=]\s*["'']([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+        - 'phpMyAdmin[^0-9<]{0,30}([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+      group: 1


### PR DESCRIPTION
two info-level modules that flag exposed database admin panels. adminer keys on the login form's
`auth[...]` field names and the `adminer.org` footer link, and extracts the version from the
footer. phpmyadmin keys on the `pma_username`/`pma_password` fields, the `pmahomme` theme path
and the `phpMyAdmin` cookie, and extracts `PMA_VERSION`. both gate on a 200 so a bare brand
mention on an unrelated page does not match.

build/vet/lint clean, `go test ./internal/modules/` green (real-hit and unrelated-page cases).
