### PR TITLE
feat(modules): add grafana, kibana and jenkins login panel modules

### DIFF
--- a/internal/modules/login_panels_test.go
+++ b/internal/modules/login_panels_test.go
@@ -1,0 +1,106 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+func runLoginModule(t *testing.T, file string, status int, headers map[string]string, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func loginExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestLoginPanelModules(t *testing.T) {
+	const grafana = "../../modules/info/grafana-panel.yaml"
+	const kibana = "../../modules/info/kibana-panel.yaml"
+	const jenkins = "../../modules/info/jenkins-panel.yaml"
+
+	grafanaBody := `<body class="app-grafana"><grafana-app></grafana-app>` +
+		`<script>window.grafanaBootData = {"settings":{"buildInfo":{"version":"10.4.2","commit":"abc"}}};</script></body>`
+	kibanaBody := `<div data-test-subj="kibanaChrome"><kbn-injected-metadata data="x"></kbn-injected-metadata></div>`
+
+	t.Run("grafana login", func(t *testing.T) {
+		res := runLoginModule(t, grafana, 200, nil, grafanaBody)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a grafana finding")
+		}
+		if v := loginExtract(res, "grafana_version"); v != "10.4.2" {
+			t.Errorf("grafana_version=%q, want 10.4.2", v)
+		}
+	})
+
+	t.Run("kibana via response headers", func(t *testing.T) {
+		res := runLoginModule(t, kibana, 200, map[string]string{"kbn-version": "8.13.0", "kbn-name": "node-1"}, kibanaBody)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a kibana finding")
+		}
+		if v := loginExtract(res, "kibana_version"); v != "8.13.0" {
+			t.Errorf("kibana_version=%q, want 8.13.0", v)
+		}
+	})
+
+	t.Run("jenkins via X-Jenkins header on a 403", func(t *testing.T) {
+		res := runLoginModule(t, jenkins, 403, map[string]string{"X-Jenkins": "2.426.1"},
+			`<html><head><title>Authentication required</title></head></html>`)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a jenkins finding")
+		}
+		if v := loginExtract(res, "jenkins_version"); v != "2.426.1" {
+			t.Errorf("jenkins_version=%q, want 2.426.1", v)
+		}
+	})
+
+	t.Run("unrelated page is not a panel", func(t *testing.T) {
+		for _, file := range []string{grafana, kibana, jenkins} {
+			if res := runLoginModule(t, file, 200, nil, "<html><body>plain</body></html>"); len(res.Findings) > 0 {
+				t.Errorf("%s: unrelated page should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/info/grafana-panel.yaml
+++ b/modules/info/grafana-panel.yaml
@@ -1,0 +1,40 @@
+# Grafana Login Panel Detection Module
+
+id: grafana-panel
+info:
+  name: Grafana Login Panel
+  author: sif
+  severity: info
+  description: Detects exposed Grafana dashboards and login panels
+  tags: [grafana, monitoring, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/login"
+    - "{{BaseURL}}"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: all
+      condition: or
+      words:
+        - "window.grafanaBootData"
+        - 'grafana-app'
+        - "<title>Grafana</title>"
+        - "grafana_session"
+
+  extractors:
+    - type: regex
+      name: grafana_version
+      part: body
+      regex:
+        - '"buildInfo":\{[^}]*"version":"([0-9]+\.[0-9]+\.[0-9]+)"'
+        - 'Grafana v([0-9]+\.[0-9]+\.[0-9]+)'
+      group: 1

--- a/modules/info/jenkins-panel.yaml
+++ b/modules/info/jenkins-panel.yaml
@@ -1,0 +1,41 @@
+# Jenkins Login Panel Detection Module
+
+id: jenkins-panel
+info:
+  name: Jenkins Login Panel
+  author: sif
+  severity: info
+  description: Detects exposed Jenkins automation server login panels
+  tags: [jenkins, ci, automation, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/login"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+        - 403
+
+    - type: word
+      part: all
+      condition: or
+      words:
+        - "X-Jenkins"
+        - "Dashboard [Jenkins]"
+        - "Welcome to Jenkins!"
+        - "j_username"
+        - "jenkins-session"
+
+  extractors:
+    - type: regex
+      name: jenkins_version
+      part: all
+      regex:
+        - 'X-Jenkins: ?([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+      group: 1

--- a/modules/info/kibana-panel.yaml
+++ b/modules/info/kibana-panel.yaml
@@ -1,0 +1,41 @@
+# Kibana Login Panel Detection Module
+
+id: kibana-panel
+info:
+  name: Kibana Login Panel
+  author: sif
+  severity: info
+  description: Detects exposed Kibana dashboards and login panels
+  tags: [kibana, elastic, monitoring, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/login"
+    - "{{BaseURL}}/app/kibana"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: all
+      condition: or
+      words:
+        - "Kbn-Version"
+        - "Kbn-Name"
+        - "kbn-injected-metadata"
+        - "kbnLoadingMessage"
+
+  extractors:
+    - type: regex
+      name: kibana_version
+      part: all
+      regex:
+        - '[Kk]bn-[Vv]ersion: ?([0-9]+\.[0-9]+(?:\.[0-9]+)?)'
+        - '"version":"([0-9]+\.[0-9]+\.[0-9]+)","buildNumber"'
+      group: 1


### PR DESCRIPTION
three info-level modules for exposed ops and ci login panels. grafana keys on
`window.grafanaBootData` and the `grafana-app` shell, and pulls the version from `buildInfo`.
kibana keys on the `kbn-version`/`kbn-name` response headers and the injected-metadata markers,
and pulls the version from the header. jenkins keys on the `X-Jenkins` header (present even when
`/` returns 403) and the login form, and pulls the version from that header. each module's
detection and version come from the same response, so the extractor only runs on a real hit.

build/vet/lint clean, `go test ./internal/modules/` green (including the kibana and jenkins
response-header paths).
