### PR TITLE
feat(modules): support or logic via matchers-condition

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -242,6 +242,25 @@ matchers:
 
 this matches responses with status 200 AND containing "ref: refs/".
 
+to require any matcher instead of all, set `matchers-condition: or` on the http
+block; the module then reports a finding when any one matcher matches.
+
+```yaml
+http:
+  matchers-condition: or
+  matchers:
+    - type: status
+      status:
+        - 401
+
+    - type: status
+      status:
+        - 403
+```
+
+this matches a 401 OR a 403 response. `matchers-condition` accepts `and` (the
+default) or `or`; any other value fails at load.
+
 ## extractors
 
 extractors pull data from responses.

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -239,7 +239,7 @@ func executeHTTPRequest(ctx context.Context, client *http.Client, r *httpRequest
 	bodyStr := string(respBody)
 
 	// Check matchers
-	if !checkMatchers(cfg.Matchers, resp, bodyStr) {
+	if !checkMatchers(cfg.Matchers, cfg.MatchersCondition, resp, bodyStr) {
 		return Finding{}, false
 	}
 
@@ -254,24 +254,38 @@ func executeHTTPRequest(ctx context.Context, client *http.Client, r *httpRequest
 	}, true
 }
 
-// checkMatchers evaluates all matchers against the response.
-func checkMatchers(matchers []Matcher, resp *http.Response, body string) bool {
+// checkMatchers combines matchers with condition "and" (default, all match) or "or" (any).
+func checkMatchers(matchers []Matcher, condition string, resp *http.Response, body string) bool {
 	if len(matchers) == 0 {
 		return false
 	}
 
-	// Default to AND condition across matchers
+	or := strings.EqualFold(condition, "or")
 	for i := range matchers {
 		matched := checkMatcher(&matchers[i], resp, body)
 		if matchers[i].Negative {
 			matched = !matched
 		}
-		if !matched {
-			return false // AND logic
+		if or && matched {
+			return true
+		}
+		if !or && !matched {
+			return false
 		}
 	}
 
-	return true
+	// and: all matched; or: none matched.
+	return !or
+}
+
+// validateMatchersCondition rejects a matchers-condition that is not "", "and", or "or".
+func validateMatchersCondition(condition string) error {
+	switch strings.ToLower(condition) {
+	case "", "and", "or":
+		return nil
+	default:
+		return fmt.Errorf("invalid matchers-condition %q (want \"and\" or \"or\")", condition)
+	}
 }
 
 // checkMatcher evaluates a single matcher.

--- a/internal/modules/matchers_condition_test.go
+++ b/internal/modules/matchers_condition_test.go
@@ -1,0 +1,132 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dropalldatabases/sif/internal/httpx"
+)
+
+func TestCheckMatchersCondition(t *testing.T) {
+	const body = "hello world"
+	resp := fakeResponse(t, 200, nil)
+
+	status200 := Matcher{Type: "status", Status: []int{200}}
+	status500 := Matcher{Type: "status", Status: []int{500}}
+	wordHit := Matcher{Type: "word", Part: "body", Words: []string{"hello"}}
+	wordMiss := Matcher{Type: "word", Part: "body", Words: []string{"absent"}}
+
+	tests := []struct {
+		name      string
+		condition string
+		matchers  []Matcher
+		expect    bool
+	}{
+		{"and both match", "and", []Matcher{status200, wordHit}, true},
+		{"and one fails", "and", []Matcher{status200, wordMiss}, false},
+		{"empty defaults to and", "", []Matcher{status200, wordMiss}, false},
+		{"or one matches", "or", []Matcher{status500, wordHit}, true},
+		{"or none match", "or", []Matcher{status500, wordMiss}, false},
+		{"or all match", "or", []Matcher{status200, wordHit}, true},
+		{"or is case-insensitive", "OR", []Matcher{status500, wordHit}, true},
+		{"and is case-insensitive", "AND", []Matcher{status200, wordMiss}, false},
+		{"or with negative pass", "or", []Matcher{{Type: "word", Part: "body", Words: []string{"absent"}, Negative: true}}, true},
+		{"or all fail with negative", "or", []Matcher{{Type: "word", Part: "body", Words: []string{"hello"}, Negative: true}, wordMiss}, false},
+		{"empty matcher list", "or", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkMatchers(tt.matchers, tt.condition, resp, body); got != tt.expect {
+				t.Errorf("checkMatchers(%q) = %v, want %v", tt.condition, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestValidateMatchersCondition(t *testing.T) {
+	for _, ok := range []string{"", "and", "or", "AND", "Or"} {
+		if err := validateMatchersCondition(ok); err != nil {
+			t.Errorf("%q should be valid: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"xor", "nand", "any", "&&"} {
+		if err := validateMatchersCondition(bad); err == nil {
+			t.Errorf("%q should be rejected", bad)
+		}
+	}
+}
+
+func TestParseMatchersConditionValidation(t *testing.T) {
+	write := func(cond string) string {
+		p := filepath.Join(t.TempDir(), "m.yaml")
+		body := fmt.Sprintf("id: mc\ntype: http\nhttp:\n  method: GET\n  paths: [\"{{BaseURL}}\"]\n  matchers-condition: %s\n  matchers:\n    - type: status\n      status: [200]\n", cond)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	if _, err := ParseYAMLModule(write("or")); err != nil {
+		t.Errorf("matchers-condition: or should parse: %v", err)
+	}
+	if _, err := ParseYAMLModule(write("xor")); err == nil {
+		t.Error("matchers-condition: xor should be rejected at load")
+	}
+}
+
+// or fires on the word match alone; and does not (status:500 fails).
+func TestExecuteHTTPModuleMatchersConditionOr(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	def := &YAMLModule{
+		ID:   "mc",
+		Type: TypeHTTP,
+		Info: YAMLModuleInfo{Severity: "info"},
+		HTTP: &HTTPConfig{
+			Method: "GET",
+			Paths:  []string{"{{BaseURL}}/"},
+			Matchers: []Matcher{
+				{Type: "status", Status: []int{500}},
+				{Type: "word", Part: "body", Words: []string{"hello"}},
+			},
+		},
+	}
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+
+	def.HTTP.MatchersCondition = "or"
+	res, err := ExecuteHTTPModule(context.Background(), srv.URL, def, opts)
+	if err != nil {
+		t.Fatalf("or: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("or: got %d findings, want 1", len(res.Findings))
+	}
+
+	def.HTTP.MatchersCondition = ""
+	res, err = ExecuteHTTPModule(context.Background(), srv.URL, def, opts)
+	if err != nil {
+		t.Fatalf("and: %v", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Fatalf("and: got %d findings, want 0 (status:500 fails)", len(res.Findings))
+	}
+}

--- a/internal/modules/matchers_test.go
+++ b/internal/modules/matchers_test.go
@@ -184,7 +184,7 @@ func TestCheckMatchers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := checkMatchers(tt.matchers, resp, body); got != tt.expect {
+			if got := checkMatchers(tt.matchers, "", resp, body); got != tt.expect {
 				t.Errorf("checkMatchers = %v, want %v", got, tt.expect)
 			}
 		})

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -53,15 +53,16 @@ type YAMLModuleInfo struct {
 
 // HTTPConfig defines HTTP module settings
 type HTTPConfig struct {
-	Method     string            `yaml:"method"`
-	Paths      []string          `yaml:"paths"`
-	Payloads   []string          `yaml:"payloads,omitempty"`
-	Headers    map[string]string `yaml:"headers,omitempty"`
-	Body       string            `yaml:"body,omitempty"`
-	Attack     string            `yaml:"attack,omitempty"` // clusterbomb (default), pitchfork
-	Threads    int               `yaml:"threads,omitempty"`
-	Matchers   []Matcher         `yaml:"matchers"`
-	Extractors []Extractor       `yaml:"extractors,omitempty"`
+	Method            string            `yaml:"method"`
+	Paths             []string          `yaml:"paths"`
+	Payloads          []string          `yaml:"payloads,omitempty"`
+	Headers           map[string]string `yaml:"headers,omitempty"`
+	Body              string            `yaml:"body,omitempty"`
+	Attack            string            `yaml:"attack,omitempty"` // clusterbomb (default), pitchfork
+	Threads           int               `yaml:"threads,omitempty"`
+	Matchers          []Matcher         `yaml:"matchers"`
+	MatchersCondition string            `yaml:"matchers-condition,omitempty"` // and (default), or
+	Extractors        []Extractor       `yaml:"extractors,omitempty"`
 }
 
 // DNSConfig defines DNS module settings
@@ -102,6 +103,9 @@ func ParseYAMLModule(path string) (*YAMLModule, error) {
 
 	if ym.HTTP != nil {
 		if err := validateAttack(ym.HTTP.Attack); err != nil {
+			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
+		}
+		if err := validateMatchersCondition(ym.HTTP.MatchersCondition); err != nil {
 			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
 		}
 	}


### PR DESCRIPTION
`checkMatchers` combined matchers with AND only. add a `matchers-condition` field accepting
`and` (default) or `or` so an http module can fire when any matcher matches instead of all;
invalid values are rejected at load.

build/vet/lint clean, `go test ./internal/modules/` green.
