### PR TITLE
feat(modules): add portainer, traefik, keycloak and rabbitmq panel modules

### DIFF
--- a/internal/modules/ops_panels_test.go
+++ b/internal/modules/ops_panels_test.go
@@ -1,0 +1,112 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+// runOpsModule runs a shipped module end to end against a server that returns
+// the same status and body for every path it requests.
+func runOpsModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func opsExtracted(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v, ok := f.Extracted[key]; ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestOpsPanelModules(t *testing.T) {
+	cases := []struct {
+		name        string
+		file        string
+		status      int
+		body        string
+		wantFinding bool
+		versionKey  string
+		versionVal  string
+	}{
+		{
+			name: "portainer status api", file: "../../modules/info/portainer-panel.yaml", status: 200,
+			body:        `{"Edition":"CE","Version":"2.19.4","InstanceID":"a1b2c3"}`,
+			wantFinding: true, versionKey: "portainer_version", versionVal: "2.19.4",
+		},
+		{
+			name: "portainer version-only json is not a match", file: "../../modules/info/portainer-panel.yaml", status: 200,
+			body: `{"Version":"1.0.0"}`, wantFinding: false,
+		},
+		{
+			name: "portainer real body behind a 404 is not a match", file: "../../modules/info/portainer-panel.yaml", status: 404,
+			body: `{"Edition":"CE","Version":"2.19.4","InstanceID":"a1b2c3"}`, wantFinding: false,
+		},
+		{
+			name: "traefik version api", file: "../../modules/info/traefik-panel.yaml", status: 200,
+			body:        `{"Version":"2.10.4","Codename":"saintnectaire","startDate":"2024-01-01T00:00:00Z"}`,
+			wantFinding: true, versionKey: "traefik_version", versionVal: "2.10.4",
+		},
+		{
+			name: "traefik without codename is not a match", file: "../../modules/info/traefik-panel.yaml", status: 200,
+			body: `{"Version":"2.10.4"}`, wantFinding: false,
+		},
+		{
+			name: "keycloak realm endpoint", file: "../../modules/info/keycloak-panel.yaml", status: 200,
+			body:        `{"realm":"master","public_key":"MIIBIjAN","token-service":"https://h/realms/master/protocol/openid-connect","account-service":"https://h/realms/master/account"}`,
+			wantFinding: true, versionKey: "keycloak_realm", versionVal: "master",
+		},
+		{
+			name: "keycloak partial realm json is not a match", file: "../../modules/info/keycloak-panel.yaml", status: 200,
+			body: `{"realm":"master","public_key":"MIIBIjAN"}`, wantFinding: false,
+		},
+		{
+			name: "rabbitmq management ui", file: "../../modules/info/rabbitmq-panel.yaml", status: 200,
+			body:        `<!DOCTYPE html><html><head><title>RabbitMQ Management</title></head><body><img src="img/rabbitmqlogo.svg"></body></html>`,
+			wantFinding: true,
+		},
+		{
+			name: "rabbitmq unrelated page is not a match", file: "../../modules/info/rabbitmq-panel.yaml", status: 200,
+			body: `<html><body>nothing to see</body></html>`, wantFinding: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := runOpsModule(t, tc.file, tc.status, tc.body)
+			got := len(res.Findings) > 0
+			if got != tc.wantFinding {
+				t.Fatalf("findings=%d, want match=%v", len(res.Findings), tc.wantFinding)
+			}
+			if tc.versionKey != "" {
+				if v := opsExtracted(res, tc.versionKey); v != tc.versionVal {
+					t.Errorf("extracted[%q]=%q, want %q", tc.versionKey, v, tc.versionVal)
+				}
+			}
+		})
+	}
+}

--- a/modules/info/keycloak-panel.yaml
+++ b/modules/info/keycloak-panel.yaml
@@ -1,0 +1,38 @@
+# Keycloak Panel Detection Module
+
+id: keycloak-panel
+info:
+  name: Keycloak Panel
+  author: sif
+  severity: info
+  description: Detects an exposed Keycloak identity server via its public realm endpoint
+  tags: [keycloak, iam, sso, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/realms/master"
+    - "{{BaseURL}}/auth/realms/master"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      condition: and
+      words:
+        - '"public_key"'
+        - '"token-service"'
+        - '"account-service"'
+
+  extractors:
+    - type: regex
+      name: keycloak_realm
+      part: body
+      regex:
+        - '"realm"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/info/portainer-panel.yaml
+++ b/modules/info/portainer-panel.yaml
@@ -1,0 +1,38 @@
+# Portainer Panel Detection Module
+
+id: portainer-panel
+info:
+  name: Portainer Panel
+  author: sif
+  severity: info
+  description: Detects exposed Portainer container management instances via the public status API
+  tags: [portainer, docker, container, panel, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/status"
+    - "{{BaseURL}}/portainer/api/status"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      condition: and
+      words:
+        - '"Edition"'
+        - '"Version"'
+        - '"InstanceID"'
+
+  extractors:
+    - type: regex
+      name: portainer_version
+      part: body
+      regex:
+        - '"Version":\s*"([0-9]+\.[0-9]+(?:\.[0-9]+)?)"'
+      group: 1

--- a/modules/info/rabbitmq-panel.yaml
+++ b/modules/info/rabbitmq-panel.yaml
@@ -1,0 +1,30 @@
+# RabbitMQ Management Detection Module
+
+id: rabbitmq-panel
+info:
+  name: RabbitMQ Management
+  author: sif
+  severity: info
+  description: Detects an exposed RabbitMQ management UI login panel
+  tags: [rabbitmq, amqp, messaging, panel, login, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}"
+    - "{{BaseURL}}/rabbitmq/"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: all
+      condition: or
+      words:
+        - "RabbitMQ Management"
+        - "rabbitmqlogo"
+        - "<title>RabbitMQ"

--- a/modules/info/traefik-panel.yaml
+++ b/modules/info/traefik-panel.yaml
@@ -1,0 +1,38 @@
+# Traefik Dashboard Detection Module
+
+id: traefik-panel
+info:
+  name: Traefik Dashboard
+  author: sif
+  severity: info
+  description: Detects an exposed Traefik API and dashboard via the public version endpoint
+  tags: [traefik, proxy, dashboard, panel, detection, info]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/version"
+    - "{{BaseURL}}/traefik/api/version"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      condition: and
+      words:
+        - '"Version"'
+        - '"Codename"'
+        - '"startDate"'
+
+  extractors:
+    - type: regex
+      name: traefik_version
+      part: body
+      regex:
+        - '"Version":\s*"v?([0-9]+\.[0-9]+(?:\.[0-9]+)?)"'
+      group: 1


### PR DESCRIPTION
four info-level modules for exposed ops admin panels and dashboards. portainer and traefik
detect via their unauthenticated json apis (`/api/status` and `/api/version`) and extract the
reported version. keycloak detects via its public `/realms/master` endpoint, and rabbitmq via
the management ui title. matchers gate on a 200 and require the product-specific keys together
(portainer needs `Edition` + `Version` + `InstanceID`, for one), so a generic json body with a
stray `Version` field does not match.

build/vet/lint clean, `go test ./internal/modules/` green (each module end to end, real-hit and
near-miss).
