### PR TITLE
feat(modules): add json extractor

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -271,6 +271,21 @@ extractors:
     part: header
 ```
 
+### json extractor
+
+extract values from a json body by gjson path (github.com/tidwall/gjson); the
+first path that exists is stored under name.
+
+```yaml
+extractors:
+  - type: json
+    name: version
+    part: body
+    json:
+      - "version"
+      - "data.version"
+```
+
 ## examples
 
 ### exposed git repository

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/projectdiscovery/retryabledns v1.0.115
 	github.com/projectdiscovery/utils v0.11.1
 	github.com/rocketlaunchr/google-search v1.1.6
+	github.com/tidwall/gjson v1.18.0
 	github.com/twmb/murmur3 v1.1.8
 	golang.org/x/net v0.56.0
 	golang.org/x/time v0.15.0
@@ -330,7 +331,6 @@ require (
 	github.com/temoto/robotstxt v1.1.2 // indirect
 	github.com/tidwall/btree v1.8.1 // indirect
 	github.com/tidwall/buntdb v1.3.2 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/grect v0.1.4 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tidwall/gjson"
 )
 
 // MaxBodySize limits response body to prevent memory exhaustion.
@@ -415,6 +417,14 @@ func runExtractors(extractors []Extractor, resp *http.Response, body string) map
 					key = e.Name + "." + k
 				}
 				result[key] = strings.Join(v, ", ")
+			}
+		case "json":
+			part := getPart(e.Part, resp, body)
+			for _, path := range e.JSON {
+				if r := gjson.Get(part, path); r.Exists() {
+					result[e.Name] = r.String()
+					break
+				}
 			}
 		}
 	}

--- a/internal/modules/json_extractor_test.go
+++ b/internal/modules/json_extractor_test.go
@@ -1,0 +1,86 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dropalldatabases/sif/internal/httpx"
+)
+
+func TestRunExtractorsJSON(t *testing.T) {
+	const body = `{"version":"1.2.3","app":{"name":"sif"},"items":[{"id":7}]}`
+	resp := fakeResponse(t, 200, nil)
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  string // "" means the extractor should set nothing
+	}{
+		{"top level", []string{"version"}, "1.2.3"},
+		{"nested", []string{"app.name"}, "sif"},
+		{"array index", []string{"items.0.id"}, "7"},
+		{"first existing wins", []string{"missing", "version"}, "1.2.3"},
+		{"no match", []string{"nope"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ex := []Extractor{{Type: "json", Name: "v", Part: "body", JSON: tt.paths}}
+			got := runExtractors(ex, resp, body)
+			if tt.want == "" {
+				if v, ok := got["v"]; ok {
+					t.Errorf("expected no extraction, got %q", v)
+				}
+				return
+			}
+			if got["v"] != tt.want {
+				t.Errorf("got %q, want %q", got["v"], tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteHTTPModuleJSONExtractor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	def := &YAMLModule{
+		ID:   "j",
+		Type: TypeHTTP,
+		Info: YAMLModuleInfo{Severity: "info"},
+		HTTP: &HTTPConfig{
+			Method:     "GET",
+			Paths:      []string{"{{BaseURL}}/"},
+			Matchers:   []Matcher{{Type: "status", Status: []int{200}}},
+			Extractors: []Extractor{{Type: "json", Name: "version", Part: "body", JSON: []string{"version"}}},
+		},
+	}
+
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+	res, err := ExecuteHTTPModule(context.Background(), srv.URL, def, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(res.Findings))
+	}
+	if got := res.Findings[0].Extracted["version"]; got != "9.9.9" {
+		t.Errorf("extracted version = %q, want 9.9.9", got)
+	}
+}

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -103,5 +103,6 @@ type Extractor struct {
 	Name  string   `yaml:"name"`
 	Part  string   `yaml:"part"`
 	Regex []string `yaml:"regex,omitempty"`
+	JSON  []string `yaml:"json,omitempty"`
 	Group int      `yaml:"group"`
 }


### PR DESCRIPTION
`runExtractors` only handled regex. add a json extractor that pulls values from a json body by
gjson path, storing the first path that exists under the extractor name. gjson was already an
indirect dependency.

build/vet/lint clean, `go test ./internal/modules/` green.
