### PR TITLE
feat(modules): add pitchfork attack mode

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -115,6 +115,18 @@ http:
 
 each payload creates a separate request for each path.
 
+#### attack
+
+how paths and payloads combine into requests.
+
+```yaml
+http:
+  attack: pitchfork
+```
+
+- `clusterbomb` (default) - every path is tried with every payload
+- `pitchfork` - path and payload are paired by index, stopping at the shorter list
+
 #### headers
 
 custom headers to send.

--- a/internal/modules/attack_modes_test.go
+++ b/internal/modules/attack_modes_test.go
@@ -1,0 +1,144 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/dropalldatabases/sif/internal/httpx"
+)
+
+func reqURLs(reqs []*httpRequest) []string {
+	urls := make([]string, len(reqs))
+	for i, r := range reqs {
+		urls[i] = r.URL
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+func TestGenerateHTTPRequestsAttack(t *testing.T) {
+	const target = "http://t"
+	paths2 := []string{"{{BaseURL}}/a?x={{payload}}", "{{BaseURL}}/b?x={{payload}}"}
+	pay2 := []string{"1", "2"}
+	cross := []string{"http://t/a?x=1", "http://t/a?x=2", "http://t/b?x=1", "http://t/b?x=2"}
+	paired := []string{"http://t/a?x=1", "http://t/b?x=2"}
+
+	tests := []struct {
+		name     string
+		paths    []string
+		payloads []string
+		attack   string
+		want     []string
+	}{
+		{"clusterbomb default crosses all", paths2, pay2, "", cross},
+		{"clusterbomb explicit crosses all", paths2, pay2, "clusterbomb", cross},
+		{"pitchfork pairs by index", paths2, pay2, "pitchfork", paired},
+		{"pitchfork stops at fewer payloads", append(paths2, "{{BaseURL}}/c?x={{payload}}"), pay2, "pitchfork", paired},
+		{"pitchfork stops at fewer paths", paths2, []string{"1", "2", "3"}, "pitchfork", paired},
+		{"attack is case insensitive", paths2, pay2, "Pitchfork", paired},
+		{"no payloads ignores attack", []string{"{{BaseURL}}/a", "{{BaseURL}}/b"}, nil, "pitchfork", []string{"http://t/a", "http://t/b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &HTTPConfig{Paths: tt.paths, Payloads: tt.payloads, Attack: tt.attack}
+			got := reqURLs(generateHTTPRequests(target, cfg))
+			want := append([]string(nil), tt.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("attack %q:\n got %v\nwant %v", tt.attack, got, want)
+			}
+		})
+	}
+}
+
+func TestValidateAttack(t *testing.T) {
+	for _, ok := range []string{"", "clusterbomb", "pitchfork", "Pitchfork", "CLUSTERBOMB"} {
+		if err := validateAttack(ok); err != nil {
+			t.Errorf("validateAttack(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"sniper", "batteringram", "bogus"} {
+		if err := validateAttack(bad); err == nil {
+			t.Errorf("validateAttack(%q) = nil, want error", bad)
+		}
+	}
+}
+
+func TestParseAttackValidation(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	good := write("good.yaml", "id: ok\ntype: http\nhttp:\n  attack: pitchfork\n  paths: [\"{{BaseURL}}/\"]\n")
+	if _, err := ParseYAMLModule(good); err != nil {
+		t.Fatalf("valid attack rejected: %v", err)
+	}
+
+	bad := write("bad.yaml", "id: bad\ntype: http\nhttp:\n  attack: sniper\n  paths: [\"{{BaseURL}}/\"]\n")
+	if _, err := ParseYAMLModule(bad); err == nil {
+		t.Fatal("invalid attack accepted")
+	}
+}
+
+// TestExecuteHTTPModulePitchfork drives the executor end to end and confirms
+// pitchfork only fires the index-paired requests, not the full cross product.
+func TestExecuteHTTPModulePitchfork(t *testing.T) {
+	var mu sync.Mutex
+	var hits []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits = append(hits, r.URL.Path+"?"+r.URL.RawQuery)
+		mu.Unlock()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	def := &YAMLModule{
+		ID:   "pf",
+		Type: TypeHTTP,
+		HTTP: &HTTPConfig{
+			Attack:   "pitchfork",
+			Paths:    []string{"{{BaseURL}}/a?x={{payload}}", "{{BaseURL}}/b?x={{payload}}"},
+			Payloads: []string{"1", "2"},
+			Matchers: []Matcher{{Type: "word", Part: "body", Words: []string{"ok"}}},
+		},
+	}
+
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+	if _, err := ExecuteHTTPModule(context.Background(), srv.URL, def, opts); err != nil {
+		t.Fatalf("ExecuteHTTPModule: %v", err)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), hits...)
+	mu.Unlock()
+	sort.Strings(got)
+	want := []string{"/a?x=1", "/b?x=2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pitchfork hit %v, want %v (clusterbomb would also hit /a?x=2 and /b?x=1)", got, want)
+	}
+}

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -149,23 +149,50 @@ func generateHTTPRequests(target string, cfg *HTTPConfig) []*httpRequest {
 		return requests
 	}
 
-	// Generate requests with payloads
+	// pitchfork pairs path[i] with payload[i] and stops at the shorter list;
+	// clusterbomb (default) crosses every path with every payload.
+	if strings.EqualFold(cfg.Attack, "pitchfork") {
+		n := len(cfg.Paths)
+		if len(cfg.Payloads) < n {
+			n = len(cfg.Payloads)
+		}
+		for i := 0; i < n; i++ {
+			requests = append(requests, newPayloadRequest(method, target, cfg.Paths[i], cfg.Payloads[i], cfg))
+		}
+		return requests
+	}
+
 	for _, path := range cfg.Paths {
 		for _, payload := range cfg.Payloads {
-			url := substituteVariables(path, target, payload)
-			body := substituteVariables(cfg.Body, target, payload)
-			requests = append(requests, &httpRequest{
-				Method:   method,
-				URL:      url,
-				Headers:  cfg.Headers,
-				Body:     body,
-				Payload:  payload,
-				Original: path,
-			})
+			requests = append(requests, newPayloadRequest(method, target, path, payload, cfg))
 		}
 	}
 
 	return requests
+}
+
+// newPayloadRequest builds one request with the path and body templates
+// substituted for the given payload.
+func newPayloadRequest(method, target, path, payload string, cfg *HTTPConfig) *httpRequest {
+	return &httpRequest{
+		Method:   method,
+		URL:      substituteVariables(path, target, payload),
+		Headers:  cfg.Headers,
+		Body:     substituteVariables(cfg.Body, target, payload),
+		Payload:  payload,
+		Original: path,
+	}
+}
+
+// validateAttack rejects an attack mode that is not "", "clusterbomb", or
+// "pitchfork"; an empty value defaults to clusterbomb.
+func validateAttack(attack string) error {
+	switch strings.ToLower(attack) {
+	case "", "clusterbomb", "pitchfork":
+		return nil
+	default:
+		return fmt.Errorf("invalid attack %q (want \"clusterbomb\" or \"pitchfork\")", attack)
+	}
 }
 
 // substituteVariables replaces template variables in a string.

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -58,7 +58,7 @@ type HTTPConfig struct {
 	Payloads   []string          `yaml:"payloads,omitempty"`
 	Headers    map[string]string `yaml:"headers,omitempty"`
 	Body       string            `yaml:"body,omitempty"`
-	Attack     string            `yaml:"attack,omitempty"` // sniper, pitchfork, clusterbomb
+	Attack     string            `yaml:"attack,omitempty"` // clusterbomb (default), pitchfork
 	Threads    int               `yaml:"threads,omitempty"`
 	Matchers   []Matcher         `yaml:"matchers"`
 	Extractors []Extractor       `yaml:"extractors,omitempty"`
@@ -98,6 +98,12 @@ func ParseYAMLModule(path string) (*YAMLModule, error) {
 
 	if ym.Type == "" {
 		return nil, fmt.Errorf("module missing required field: type")
+	}
+
+	if ym.HTTP != nil {
+		if err := validateAttack(ym.HTTP.Attack); err != nil {
+			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
+		}
 	}
 
 	return &ym, nil


### PR DESCRIPTION
the `attack` field was parsed but never read, so every module ran the clusterbomb
cross-product. wire it up: `pitchfork` pairs `path[i]` with `payload[i]` and stops at the
shorter list, `clusterbomb` stays the default, and an unknown attack value is rejected at
parse time instead of silently ignored. `sniper` is deliberately left out: a faithful sniper
needs multiple payload positions with base values, which the single flat `payloads` list and
one `{{payload}}` token can't model, so it would collapse into clusterbomb for >1 path; it
can follow once named payload sets exist.

build/vet/lint clean, `go test ./internal/modules/` green (generator even/uneven, validator,
parse-time rejection, end-to-end pitchfork).
