### PR TITLE
feat(modules): add ignition, profiler and heapdump exposure modules

### DIFF
--- a/internal/modules/debug_exposure_test.go
+++ b/internal/modules/debug_exposure_test.go
@@ -1,0 +1,121 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+func runDebugModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func debugExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestDebugExposureModules(t *testing.T) {
+	const ignition = "../../modules/recon/laravel-ignition-exposure.yaml"
+	const profiler = "../../modules/recon/symfony-profiler-exposure.yaml"
+	const heapdump = "../../modules/recon/spring-heapdump-exposure.yaml"
+
+	t.Run("ignition health check exposes command execution", func(t *testing.T) {
+		res := runDebugModule(t, ignition, 200, `{"can_execute_commands":true,"config":{}}`)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an ignition finding")
+		}
+		if v := debugExtract(res, "can_execute_commands"); v != "true" {
+			t.Errorf("can_execute_commands=%q, want true", v)
+		}
+	})
+
+	t.Run("ignition exposed with debug off still flags and extracts false", func(t *testing.T) {
+		res := runDebugModule(t, ignition, 200, `{"can_execute_commands":false}`)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an ignition finding even when command execution is off")
+		}
+		if v := debugExtract(res, "can_execute_commands"); v != "false" {
+			t.Errorf("can_execute_commands=%q, want false", v)
+		}
+	})
+
+	t.Run("symfony profiler exposes a request token", func(t *testing.T) {
+		body := `<html><head><title>Symfony Profiler</title></head><body>` +
+			`<a href="/_profiler/5f3a2b">GET /</a></body></html>`
+		res := runDebugModule(t, profiler, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a symfony profiler finding")
+		}
+		if v := debugExtract(res, "profiler_token"); v != "5f3a2b" {
+			t.Errorf("profiler_token=%q, want 5f3a2b", v)
+		}
+	})
+
+	t.Run("spring heap dump exposes the hprof magic", func(t *testing.T) {
+		body := "JAVA PROFILE 1.0.2\x00\x00\x00\x08heap bytes follow"
+		res := runDebugModule(t, heapdump, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a heap dump finding")
+		}
+		if v := debugExtract(res, "hprof_version"); v != "1.0.2" {
+			t.Errorf("hprof_version=%q, want 1.0.2", v)
+		}
+	})
+
+	t.Run("the hprof magic must be at the start not merely present", func(t *testing.T) {
+		body := "<html><body>docs about the JAVA PROFILE 1.0.2 hprof header</body></html>"
+		if res := runDebugModule(t, heapdump, 200, body); len(res.Findings) > 0 {
+			t.Errorf("the magic away from the start should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a page that only names ignition is not the endpoint", func(t *testing.T) {
+		body := `<html><body>we use ignition to render errors in development</body></html>`
+		if res := runDebugModule(t, ignition, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a prose mention should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{ignition, profiler, heapdump} {
+			if res := runDebugModule(t, file, 200, "<html><body>plain</body></html>"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{ignition, profiler, heapdump} {
+			if res := runDebugModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/recon/laravel-ignition-exposure.yaml
+++ b/modules/recon/laravel-ignition-exposure.yaml
@@ -1,0 +1,34 @@
+# Laravel Ignition Debug Exposure Detection Module
+
+id: laravel-ignition-exposure
+info:
+  name: Laravel Ignition Debug Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Laravel Ignition debug endpoint that may allow remote code execution
+  tags: [laravel, ignition, debug, rce, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/_ignition/health-check"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "can_execute_commands"
+
+  extractors:
+    - type: regex
+      name: can_execute_commands
+      part: body
+      regex:
+        - '"can_execute_commands"\s*:\s*(true|false)'
+      group: 1

--- a/modules/recon/spring-heapdump-exposure.yaml
+++ b/modules/recon/spring-heapdump-exposure.yaml
@@ -1,0 +1,35 @@
+# Spring Boot Heap Dump Exposure Detection Module
+
+id: spring-heapdump-exposure
+info:
+  name: Spring Boot Heap Dump Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Spring Boot actuator heap dump that leaks application memory and secrets
+  tags: [spring, actuator, heapdump, exposure, secrets, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/actuator/heapdump"
+    - "{{BaseURL}}/heapdump"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - '^JAVA PROFILE 1\.0'
+
+  extractors:
+    - type: regex
+      name: hprof_version
+      part: body
+      regex:
+        - '^JAVA PROFILE (1\.0\.\d)'
+      group: 1

--- a/modules/recon/symfony-profiler-exposure.yaml
+++ b/modules/recon/symfony-profiler-exposure.yaml
@@ -1,0 +1,38 @@
+# Symfony Profiler Exposure Detection Module
+
+id: symfony-profiler-exposure
+info:
+  name: Symfony Profiler Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Symfony web profiler that leaks requests, configuration and environment
+  tags: [symfony, profiler, debug, exposure, info-disclosure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/_profiler"
+    - "{{BaseURL}}/app_dev.php/_profiler"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      condition: or
+      words:
+        - "Symfony Profiler"
+        - "sf-profiler"
+        - "sf-toolbar"
+
+  extractors:
+    - type: regex
+      name: profiler_token
+      part: body
+      regex:
+        - '/_profiler/([0-9a-f]{6,})'
+      group: 1


### PR DESCRIPTION
`modules/recon/laravel-ignition-exposure.yaml` probes the live `/_ignition/health-check`
endpoint and extracts `can_execute_commands`, the flag that marks the CVE-2021-3129 rce
surface; an active probe complementary to the version-based ignition entry in the framework cve
map. `modules/recon/symfony-profiler-exposure.yaml` flags an exposed web profiler on its
structural markers and extracts a request token to pivot to a captured request.
`modules/recon/spring-heapdump-exposure.yaml` flags an exposed actuator heap dump on the hprof
magic anchored at the start of the body (which a json-marker module cannot see, the dump being
binary) and extracts the hprof version; the anchor keeps a page that merely quotes the magic
from matching.

build/vet/lint clean, `go test ./internal/modules/` green (three modules end to end via `ExecuteHTTPModule`;
near-misses: prose mention, hprof magic off-start, plain 200, 404; plus ignition with
command-exec disabled still flags and reports the false flag).
