### PR TITLE
fix(scan): crack weak hmac secrets on hs384 and hs512 tokens

### DIFF
--- a/internal/scan/jwt.go
+++ b/internal/scan/jwt.go
@@ -16,9 +16,11 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"regexp"
@@ -233,7 +235,7 @@ func analyzeJWT(source, raw string) (JWTToken, bool) {
 	// only bother cracking when the alg is actually hmac; an asymmetric token
 	// has no shared secret to guess.
 	if isHMACAlg(alg) {
-		if secret, ok := crackHMAC(raw); ok {
+		if secret, ok := crackHMAC(raw, alg); ok {
 			token.WeakKey = secret
 			token.Issues = append(token.Issues, JWTIssue{
 				Kind:     "weak hmac secret",
@@ -309,11 +311,15 @@ func jwtClaimIssues(payload map[string]any) []JWTIssue {
 	return issues
 }
 
-// crackHMAC tries every bundled weak secret against the token's HS256 signature
-// offline. a verifying secret means the token is forgeable by anyone who knows
-// it. only HS256 is attempted; the wordlist exists to catch lazy defaults, not
-// to be a real cracker.
-func crackHMAC(raw string) (string, bool) {
+// crackHMAC tries every bundled weak secret against the token's signature offline,
+// using the hash that matches alg (HS256/HS384/HS512). a verifying secret means the
+// token is forgeable; the wordlist catches lazy defaults, it is not a real cracker.
+func crackHMAC(raw, alg string) (string, bool) {
+	newHash, ok := hmacHash(alg)
+	if !ok {
+		return "", false
+	}
+
 	parts := strings.Split(raw, ".")
 	if len(parts) != 3 {
 		return "", false
@@ -326,13 +332,29 @@ func crackHMAC(raw string) (string, bool) {
 
 	for i := 0; i < len(jwtWeakSecrets); i++ {
 		secret := jwtWeakSecrets[i]
-		mac := hmac.New(sha256.New, []byte(secret))
+		mac := hmac.New(newHash, []byte(secret))
 		mac.Write([]byte(signingInput))
 		if hmac.Equal(mac.Sum(nil), want) {
 			return secret, true
 		}
 	}
 	return "", false
+}
+
+// hmacHash maps an HMAC jwt alg to its hash constructor; ok is false for any
+// non-HMAC or unknown alg. it is stricter than isHMACAlg: the confusion-surface
+// finding fires on any HS* alg, but cracking needs a computable digest width.
+func hmacHash(alg string) (func() hash.Hash, bool) {
+	switch strings.ToUpper(alg) {
+	case "HS256":
+		return sha256.New, true
+	case "HS384":
+		return sha512.New384, true
+	case "HS512":
+		return sha512.New, true
+	default:
+		return nil, false
+	}
 }
 
 // decodeJWTSegment base64url-decodes one jwt segment into a claims map. jwt uses

--- a/internal/scan/jwt_test.go
+++ b/internal/scan/jwt_test.go
@@ -39,6 +39,25 @@ const (
 	jwtSensitive = "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
 		"eyJzdWIiOiAieCIsICJwYXNzd29yZCI6ICJodW50ZXIyIiwgImV4cCI6IDk5OTk5OTk5OTl9." +
 		"rjEf0CUa7_qppuINi6zL9vupJIX0rzSBhul7kKM9uSA"
+
+	// HS384, signed with the bundled weak secret "secret".
+	jwtWeakHS384 = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InRlc3RlciJ9." +
+		"OXNTuzKiGLxnpUjL24vvKlQzdOD-YKMinN8eu_v5luTXDUF65bHAQnz-M3VG2TVh"
+
+	// HS512, signed with the bundled weak secret "secret".
+	jwtWeakHS512 = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InRlc3RlciJ9." +
+		"CXcZz0F9TTPg--B4WV1Vzty3gG_wcDG86H5QDSRe94MpcVXIcRTBK6H7OmqFyG4nNWYNXPOODCu426bgQMOzRQ"
+
+	// HS384/HS512 signed with a strong secret absent from the wordlist; these
+	// must never be cracked (no false positive on the wide-digest path).
+	jwtStrongHS384 = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InRlc3RlciJ9." +
+		"vHhjZPoXZnnZEvVYxX64J2wm8qWk-e6y_T20qTy_Su6sPmoUSMHS4tv6_D-hfwrY"
+	jwtStrongHS512 = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6InRlc3RlciJ9." +
+		"80ueFa0oI88ftySkn_MJ12GAd1r2cahXt_ICtCfWx58wJoAvEocbjBPC_efzOp8vm_39GlcCCDLeb6cFix3DBw"
 )
 
 // hasIssue reports whether the analyzed token carries an issue of the given kind.
@@ -105,6 +124,123 @@ func TestJWT_WeakSecretCracked(t *testing.T) {
 	}
 	if !hasIssue(token, "rs256->hs256 confusion surface") {
 		t.Errorf("expected hmac confusion surface to be flagged, got %+v", token.Issues)
+	}
+}
+
+func TestJWT_WeakSecretCrackedHS384HS512(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"HS384", jwtWeakHS384},
+		{"HS512", jwtWeakHS512},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.SetCookie(w, &http.Cookie{Name: "session", Value: tc.token})
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			result, err := JWT(srv.URL, 5*time.Second, "")
+			if err != nil {
+				t.Fatalf("JWT: %v", err)
+			}
+			if result == nil || len(result.Tokens) != 1 {
+				t.Fatalf("expected one token, got %+v", result)
+			}
+
+			token := &result.Tokens[0]
+			if token.WeakKey != "secret" {
+				t.Errorf("expected weak secret 'secret' cracked on %s, got %q", tc.name, token.WeakKey)
+			}
+			if !hasIssue(token, "weak hmac secret") {
+				t.Errorf("expected weak hmac secret issue on %s, got %+v", tc.name, token.Issues)
+			}
+		})
+	}
+}
+
+func TestJWT_StrongSecretNotCrackedHS384HS512(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"HS384", jwtStrongHS384},
+		{"HS512", jwtStrongHS512},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.SetCookie(w, &http.Cookie{Name: "session", Value: tc.token})
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			result, err := JWT(srv.URL, 5*time.Second, "")
+			if err != nil {
+				t.Fatalf("JWT: %v", err)
+			}
+			if result == nil || len(result.Tokens) != 1 {
+				t.Fatalf("expected one token, got %+v", result)
+			}
+
+			token := &result.Tokens[0]
+			if token.WeakKey != "" {
+				t.Errorf("strong-secret %s token must not be cracked, got %q", tc.name, token.WeakKey)
+			}
+			if hasIssue(token, "weak hmac secret") {
+				t.Errorf("strong-secret %s token must not raise a weak-secret issue, got %+v", tc.name, token.Issues)
+			}
+		})
+	}
+}
+
+func TestHMACHash(t *testing.T) {
+	cases := []struct {
+		alg      string
+		wantOK   bool
+		wantSize int // digest bytes when ok
+	}{
+		{"HS256", true, 32},
+		{"HS384", true, 48},
+		{"HS512", true, 64},
+		{"hs256", true, 32}, // alg match is case-insensitive
+		{"", false, 0},
+		{"none", false, 0},
+		{"RS256", false, 0},
+		{"ES256", false, 0},
+		{"HS1", false, 0},
+		{"HS", false, 0},
+	}
+	for _, tc := range cases {
+		newHash, ok := hmacHash(tc.alg)
+		if ok != tc.wantOK {
+			t.Errorf("hmacHash(%q) ok = %v, want %v", tc.alg, ok, tc.wantOK)
+			continue
+		}
+		if ok && newHash().Size() != tc.wantSize {
+			t.Errorf("hmacHash(%q) digest size = %d, want %d", tc.alg, newHash().Size(), tc.wantSize)
+		}
+	}
+}
+
+func TestCrackHMAC_RejectsMalformedAndNonHMAC(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		alg  string
+	}{
+		{"non-hmac alg", jwtWeakHS384, "RS256"},
+		{"unknown hs alg", jwtWeakHS384, "HS1"},
+		{"too few parts", "only.two", "HS256"},
+		{"non-base64 signature", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.!!!notb64!!!", "HS256"},
+	}
+	for _, tc := range cases {
+		if secret, ok := crackHMAC(tc.raw, tc.alg); ok || secret != "" {
+			t.Errorf("%s: crackHMAC = (%q, %v), want (\"\", false)", tc.name, secret, ok)
+		}
 	}
 }
 


### PR DESCRIPTION
the jwt weak-secret cracker always hashed with sha-256 while `crackHMAC` was called for the
whole hmac family (`isHMACAlg` accepts HS256/HS384/HS512). on an HS384/HS512 token it compared
a 32-byte digest against a 48/64-byte signature, so `hmac.Equal` could never match and
weak-secret detection silently never fired on those tokens. `crackHMAC` now selects the digest
by alg via a new `hmacHash` helper (HS256 -> sha256, HS384 -> sha512.New384, HS512 ->
sha512.New); an unknown or non-hmac alg cracks nothing. `hmacHash` is intentionally stricter
than `isHMACAlg`, which still flags any HS* alg for the confusion-surface finding.

build/vet/lint clean, `go test ./internal/scan/` green (HS384/HS512 weak-secret cracks proven
red-before/green-after, strong-secret negatives, an `hmacHash` digest-width table, a malformed
no-panic case).
