### PR TITLE
fix(scan): don't follow redirects when probing cors

### DIFF
--- a/internal/scan/cors.go
+++ b/internal/scan/cors.go
@@ -42,10 +42,6 @@ type CORSFinding struct {
 	Note             string `json:"note"`
 }
 
-// corsMaxRedirects caps the redirect chain so we read the cors headers off the
-// host we actually asked about, not whatever it bounces us to.
-const corsMaxRedirects = 3
-
 // the sentinel attacker origin; if it comes back in Access-Control-Allow-Origin
 // the target reflects arbitrary origins and any site can read the response.
 const corsEvilOrigin = "https://sif-cors-probe.evil.com"
@@ -97,11 +93,10 @@ func CORS(targetURL string, timeout time.Duration, threads int, logdir string) (
 	host := parsedURL.Host
 
 	client := httpx.Client(timeout)
-	client.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
-		if len(via) >= corsMaxRedirects {
-			return http.ErrUseLastResponse
-		}
-		return nil
+	// don't follow redirects: cors is judged on the host we asked about, so a
+	// bounce to a permissive third party can't be pinned on the target.
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
 
 	result := &CORSResult{Findings: make([]CORSFinding, 0, len(corsOrigins))}

--- a/internal/scan/cors_test.go
+++ b/internal/scan/cors_test.go
@@ -15,6 +15,7 @@ package scan
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -129,6 +130,38 @@ func TestCORS_NoFalsePositiveOnSafeServer(t *testing.T) {
 				t.Errorf("expected no findings on safe server, got %+v", result.Findings)
 			}
 		})
+	}
+}
+
+// TestCORS_JudgesRequestedHostNotRedirectTarget pins the redirect behavior: the
+// requested host bounces to a reflecting third party, so following the redirect would
+// pin that party's misconfig on the target. the counter proves we never left the host.
+func TestCORS_JudgesRequestedHostNotRedirectTarget(t *testing.T) {
+	var destHits int32
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&destHits, 1)
+		if origin := r.Header.Get("Origin"); origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer dest.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	result, err := CORS(redirector.URL, 5*time.Second, 3, "")
+	if err != nil {
+		t.Fatalf("CORS: %v", err)
+	}
+	if n := atomic.LoadInt32(&destHits); n != 0 {
+		t.Errorf("followed the redirect to the reflecting host %d time(s); cors must stay on the requested host", n)
+	}
+	if result != nil && len(result.Findings) > 0 {
+		t.Errorf("expected no findings: the reflection is on the redirect target, not the requested host; got %+v", result.Findings)
 	}
 }
 

--- a/internal/scan/xss.go
+++ b/internal/scan/xss.go
@@ -47,6 +47,10 @@ type XSSFinding struct {
 // xssMaxBody caps the body we scan for the canary (100KB).
 const xssMaxBody = 1024 * 100
 
+// xssMaxRedirects caps the redirect chain we follow before reading the body; a
+// reflection can land a hop past the first response.
+const xssMaxRedirects = 3
+
 // canaryToken is a unique, alnum-only marker we can grep for unambiguously; it
 // survives every output encoder so a missing reflection means no echo at all.
 const canaryToken = "sifxss9173canary" //nolint:gosec // not a credential, just a reflection marker
@@ -97,7 +101,7 @@ func XSS(targetURL string, timeout time.Duration, threads int, logdir string) (*
 
 	client := httpx.Client(timeout)
 	client.CheckRedirect = func(_ *http.Request, via []*http.Request) error {
-		if len(via) >= corsMaxRedirects {
+		if len(via) >= xssMaxRedirects {
 			return http.ErrUseLastResponse
 		}
 		return nil


### PR DESCRIPTION
the cors probe followed up to three redirects, then read the cors headers off the final
response. its own comment said the cap existed so the headers came from the host we asked
about, so the code contradicted its intent: a target that only redirects to a permissive third
party had that party's misconfiguration reported against it. stop following redirects, matching
the open-redirect scanner's no-follow behavior. the redirect cap was a const shared with the
xss probe, so xss now owns its own `xssMaxRedirects` with its follow behavior unchanged.

build/vet/lint clean, `go test ./internal/scan/` green
(`TestCORS_JudgesRequestedHostNotRedirectTarget`: a host that only bounces to a reflecting
third party yields no finding, an atomic hit-counter proves the probe never leaves the
requested host; fails on the old code with six misattributed findings).
