### PR TITLE
fix(scan): don't flag quotes reflected in text as attribute xss

### DIFF
--- a/internal/scan/xss.go
+++ b/internal/scan/xss.go
@@ -234,8 +234,9 @@ func probeXSS(client *http.Client, parsedURL *url.URL, existing url.Values, para
 
 // classifyXSSContext guesses where the canary was reflected. We look at the
 // markup immediately around the token: a live <canary> tag means html text, a
-// reflection inside a <script> block means js, otherwise it sits in an attribute
-// value. The html-tag check wins because it's the most directly exploitable.
+// reflection inside a <script> block means js, a reflection sitting inside a tag
+// is an attribute value, and anything else is inert element text. The html-tag
+// check wins because it's the most directly exploitable.
 func classifyXSSContext(body string) string {
 	// a surviving "<canary>" means the < and > both passed through into markup
 	if strings.Contains(body, "<"+canaryToken+">") {
@@ -259,8 +260,34 @@ func classifyXSSContext(body string) string {
 		body = body[open+closeIdx+len("</script>"):]
 	}
 
-	// default: echoed inside an html attribute value
-	return "attribute"
+	// only an attribute value when the canary actually lands inside a tag; a quote
+	// can only break out of a delimiter that exists. assuming attribute by default
+	// flags inert quotes in element text (angle brackets escaped) as a high finding.
+	if reflectedInsideTag(body) {
+		return "attribute"
+	}
+
+	// reflected in element text: with the angle brackets escaped there's no markup
+	// to break into, so surviving quotes are harmless.
+	return "text"
+}
+
+// reflectedInsideTag reports whether any canary occurrence sits inside an open html
+// tag, the only place a surviving quote can close an attribute value and break out.
+// true when the nearest preceding '<' is not yet closed by a '>'. it's a cheap byte-scan,
+// not a parser, so a stray '<' or a quoted '>' can mis-bucket rare malformed markup.
+func reflectedInsideTag(body string) bool {
+	for off := 0; ; {
+		i := strings.Index(body[off:], canaryToken)
+		if i < 0 {
+			return false
+		}
+		pos := off + i
+		if strings.LastIndex(body[:pos], "<") > strings.LastIndex(body[:pos], ">") {
+			return true
+		}
+		off = pos + len(canaryToken)
+	}
 }
 
 // survivingBreakChars reports which dangerous chars came back next to the canary
@@ -309,6 +336,9 @@ func survivingBreakChars(body string) []string {
 // backticks matter inside attributes/scripts.
 func relevantForContext(reflectCtx string, survived []string) []string {
 	wanted := make(map[string]bool, len(survived))
+	// a context with no exploitable delimiter (e.g. "text") is left unlisted and
+	// falls through to an empty set, which drops the finding; a default case here
+	// would resurrect the inert-reflection false positive.
 	switch reflectCtx {
 	case "html":
 		wanted["<"] = true

--- a/internal/scan/xss_test.go
+++ b/internal/scan/xss_test.go
@@ -16,6 +16,7 @@ import (
 	"html"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -29,6 +30,36 @@ func reflectsRaw(param string) *httptest.Server {
 		w.WriteHeader(http.StatusOK)
 		//nolint:gosec // deliberate reflected-xss fixture for the probe under test
 		w.Write([]byte("<html><body><div>" + v + "</div></body></html>"))
+	}))
+}
+
+// reflectsQuotesInText echoes the param into element text but escapes only the
+// angle brackets, the way an encoder limited to < > & does. quotes survive raw,
+// yet in text context they delimit nothing, so this is not an injection sink.
+func reflectsQuotesInText(param string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := r.URL.Query().Get(param)
+		v = strings.ReplaceAll(v, "<", "&lt;")
+		v = strings.ReplaceAll(v, ">", "&gt;")
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		//nolint:gosec // fixture: quotes raw in element text is not exploitable
+		w.Write([]byte("<html><body><p>no results for " + v + "</p></body></html>"))
+	}))
+}
+
+// reflectsInAttribute echoes the param into a tag attribute value with the angle
+// brackets escaped but quotes raw. a surviving quote closes the value and breaks
+// out, so this is a genuine attribute-context sink the fix must still report.
+func reflectsInAttribute(param string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := r.URL.Query().Get(param)
+		v = strings.ReplaceAll(v, "<", "&lt;")
+		v = strings.ReplaceAll(v, ">", "&gt;")
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		//nolint:gosec // deliberate attribute-context xss fixture for the probe under test
+		w.Write([]byte(`<html><body><input value="` + v + `"></body></html>`))
 	}))
 }
 
@@ -98,6 +129,45 @@ func TestXSS_NoFalsePositiveWhenNotReflected(t *testing.T) {
 	}
 }
 
+func TestXSS_NoFalsePositiveOnQuotesInText(t *testing.T) {
+	srv := reflectsQuotesInText("q")
+	defer srv.Close()
+
+	result, err := XSS(srv.URL, 5*time.Second, 4, "")
+	if err != nil {
+		t.Fatalf("XSS: %v", err)
+	}
+	if result != nil && len(result.Findings) > 0 {
+		t.Errorf("quotes reflected in element text are inert; expected no findings, got %+v", result.Findings)
+	}
+}
+
+func TestXSS_DetectsAttributeReflection(t *testing.T) {
+	srv := reflectsInAttribute("q")
+	defer srv.Close()
+
+	result, err := XSS(srv.URL, 5*time.Second, 4, "")
+	if err != nil {
+		t.Fatalf("XSS: %v", err)
+	}
+	if result == nil || len(result.Findings) == 0 {
+		t.Fatalf("expected an attribute-context finding, got %+v", result)
+	}
+
+	var found *XSSFinding
+	for i := range result.Findings {
+		if result.Findings[i].Parameter == "q" {
+			found = &result.Findings[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a finding on param 'q', got %+v", result.Findings)
+	}
+	if found.Context != "attribute" {
+		t.Errorf("expected attribute context, got %s", found.Context)
+	}
+}
+
 func TestClassifyXSSContext(t *testing.T) {
 	tests := []struct {
 		name string
@@ -118,6 +188,11 @@ func TestClassifyXSSContext(t *testing.T) {
 			name: "attribute value",
 			body: `<input value="` + canaryToken + `">`,
 			want: "attribute",
+		},
+		{
+			name: "escaped brackets in element text",
+			body: `<p>no results for &lt;` + canaryToken + `&gt;"` + canaryToken + `'</p>`,
+			want: "text",
 		},
 	}
 


### PR DESCRIPTION
`classifyXSSContext` defaulted any non-html, non-script reflection to attribute context. a
reflection echoed into element text with the angle brackets escaped but quotes left raw (common
for encoders limited to `< > &`) was then reported as a high-severity attribute injection, even
though a quote in text content has no delimiter to break out of. classify a reflection as
attribute only when the canary actually lands inside an open tag; everything else is inert
element text and yields no finding. the in-tag test is a byte-scan, not a parser, so rare
malformed markup can still mis-bucket.

build/vet/lint clean, `go test ./internal/scan/` green.
