### PR TITLE
feat(modules): add vault, consul and etcd api exposure modules

### DIFF
--- a/internal/modules/orchestration_api_exposure_test.go
+++ b/internal/modules/orchestration_api_exposure_test.go
@@ -1,0 +1,132 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+func runOrchModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func orchExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestOrchestrationAPIExposureModules(t *testing.T) {
+	const vault = "../../modules/recon/vault-api-exposure.yaml"
+	const consul = "../../modules/recon/consul-api-exposure.yaml"
+	const etcd = "../../modules/recon/etcd-api-exposure.yaml"
+
+	vaultSeal := `{"type":"shamir","initialized":true,"sealed":false,"t":3,"n":5,` +
+		`"progress":0,"nonce":"","version":"1.15.2","build_date":"2023-11-06T11:33:49Z",` +
+		`"migration":false,"cluster_name":"vault-cluster-9d52b1f1","recovery_seal":false,` +
+		`"storage_type":"raft"}`
+
+	consulSelf := `{"Config":{"Datacenter":"dc1","NodeName":"consul-server-1","Server":true,` +
+		`"Version":"1.17.0"},"Member":{"Name":"consul-server-1","Addr":"10.0.0.5","Port":8301}}`
+
+	etcdVersion := `{"etcdserver":"3.5.9","etcdcluster":"3.5.0"}`
+
+	t.Run("an exposed vault seal-status is flagged and versioned", func(t *testing.T) {
+		res := runOrchModule(t, vault, 200, vaultSeal)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a vault finding")
+		}
+		if v := orchExtract(res, "vault_version"); v != "1.15.2" {
+			t.Errorf("vault_version=%q, want 1.15.2", v)
+		}
+	})
+
+	t.Run("an exposed consul agent self leaks the datacenter", func(t *testing.T) {
+		res := runOrchModule(t, consul, 200, consulSelf)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a consul finding")
+		}
+		if v := orchExtract(res, "consul_datacenter"); v != "dc1" {
+			t.Errorf("consul_datacenter=%q, want dc1", v)
+		}
+	})
+
+	t.Run("an exposed etcd version endpoint is flagged and versioned", func(t *testing.T) {
+		res := runOrchModule(t, etcd, 200, etcdVersion)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an etcd finding")
+		}
+		if v := orchExtract(res, "etcd_version"); v != "3.5.9" {
+			t.Errorf("etcd_version=%q, want 3.5.9", v)
+		}
+	})
+
+	t.Run("a sealed flag without the other vault keys is not vault", func(t *testing.T) {
+		body := `{"sealed":"yes","status":"ok"}`
+		if res := runOrchModule(t, vault, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a bare sealed flag should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a datacenter field alone is not consul", func(t *testing.T) {
+		body := `{"Datacenter":"dc1"}`
+		if res := runOrchModule(t, consul, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a bare datacenter field should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a version response from another service is not etcd", func(t *testing.T) {
+		body := `{"version":"1.2.3","service":"myapp"}`
+		if res := runOrchModule(t, etcd, 200, body); len(res.Findings) > 0 {
+			t.Errorf("another service version should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an etcdserver without an etcdcluster is not flagged", func(t *testing.T) {
+		body := `{"etcdserver":"3.5.9"}`
+		if res := runOrchModule(t, etcd, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a partial etcd response should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{vault, consul, etcd} {
+			if res := runOrchModule(t, file, 200, "ok"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{vault, consul, etcd} {
+			if res := runOrchModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/recon/consul-api-exposure.yaml
+++ b/modules/recon/consul-api-exposure.yaml
@@ -1,0 +1,44 @@
+# Consul API Exposure Detection Module
+
+id: consul-api-exposure
+info:
+  name: Consul API Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Consul http api that leaks the agent config without an acl token
+  tags: [consul, hashicorp, service-discovery, api, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/v1/agent/self"
+    - "{{BaseURL}}/v1/catalog/nodes"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"Datacenter\""
+
+    - type: word
+      part: body
+      condition: or
+      words:
+        - "\"NodeName\""
+        - "\"Server\""
+        - "\"Member\""
+        - "\"Address\""
+
+  extractors:
+    - type: regex
+      name: consul_datacenter
+      part: body
+      regex:
+        - '"Datacenter"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/etcd-api-exposure.yaml
+++ b/modules/recon/etcd-api-exposure.yaml
@@ -1,0 +1,39 @@
+# etcd API Exposure Detection Module
+
+id: etcd-api-exposure
+info:
+  name: etcd API Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed etcd api whose keyspace often holds kubernetes secrets
+  tags: [etcd, kubernetes, key-value, api, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/version"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"etcdserver\""
+
+    - type: word
+      part: body
+      words:
+        - "\"etcdcluster\""
+
+  extractors:
+    - type: regex
+      name: etcd_version
+      part: body
+      regex:
+        - '"etcdserver"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
+      group: 1

--- a/modules/recon/vault-api-exposure.yaml
+++ b/modules/recon/vault-api-exposure.yaml
@@ -1,0 +1,44 @@
+# Vault API Exposure Detection Module
+
+id: vault-api-exposure
+info:
+  name: Vault API Exposure
+  author: sif
+  severity: medium
+  description: Detects an internet reachable HashiCorp Vault through its unauthenticated status api
+  tags: [vault, hashicorp, secrets, api, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/v1/sys/seal-status"
+    - "{{BaseURL}}/v1/sys/health"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"sealed\""
+
+    - type: word
+      part: body
+      condition: or
+      words:
+        - "\"initialized\""
+        - "\"cluster_name\""
+        - "\"recovery_seal\""
+        - "\"storage_type\""
+
+  extractors:
+    - type: regex
+      name: vault_version
+      part: body
+      regex:
+        - '"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
+      group: 1


### PR DESCRIPTION
`modules/recon/vault-api-exposure.yaml` flags an internet-reachable hashicorp vault through its
unauthenticated seal-status, keyed on the `sealed` flag paired with a vault-only status field,
then extracts the version for cve matching. `modules/recon/consul-api-exposure.yaml` flags a
consul http api that answers without an acl token, keyed on the `Datacenter` field paired with
an agent or node marker, then extracts the datacenter. `modules/recon/etcd-api-exposure.yaml`
flags an exposed etcd through its version endpoint, keyed on the `etcdserver` and `etcdcluster`
fields a generic version response does not carry, then extracts the server version.

build/vet/lint clean, `go test ./internal/modules/` green (three modules end to end via
`ExecuteHTTPModule`; near-misses pinned: a sealed flag with no vault field, a datacenter field
alone, a version response from another service, a partial etcd reply, plain 200, 404).
