### PR TITLE
feat(modules): add svn, mercurial and bazaar exposure modules

### DIFF
--- a/internal/modules/vcs_metadata_exposure_test.go
+++ b/internal/modules/vcs_metadata_exposure_test.go
@@ -1,0 +1,155 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+func runVCSModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func vcsExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestVCSMetadataExposureModules(t *testing.T) {
+	const svn = "../../modules/recon/svn-exposure.yaml"
+	const hg = "../../modules/recon/mercurial-exposure.yaml"
+	const bzr = "../../modules/recon/bazaar-exposure.yaml"
+
+	svnWcDb := "SQLite format 3\x00" + strings.Repeat("\x00", 80) +
+		"CREATE TABLE WCROOT (id INTEGER PRIMARY KEY);" +
+		"CREATE TABLE REPOSITORY (root TEXT, uuid TEXT);" +
+		"\x01root\x00https://svn.example.com/myrepo/trunk\x00"
+
+	hgRequires := "revlogv1\nstore\nfncache\ndotencode\ngeneraldelta\nsparserevlog\n"
+
+	bzrFormat := "Bazaar-NG meta directory, format 1\n"
+
+	t.Run("an exposed svn wc.db leaks the repository url", func(t *testing.T) {
+		res := runVCSModule(t, svn, 200, svnWcDb)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an svn finding")
+		}
+		if v := vcsExtract(res, "svn_repository"); v != "https://svn.example.com/myrepo/trunk" {
+			t.Errorf("svn_repository=%q, want https://svn.example.com/myrepo/trunk", v)
+		}
+	})
+
+	t.Run("an exposed mercurial requires is flagged", func(t *testing.T) {
+		res := runVCSModule(t, hg, 200, hgRequires)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a mercurial finding")
+		}
+		if v := vcsExtract(res, "hg_requirement"); v != "revlogv1" {
+			t.Errorf("hg_requirement=%q, want revlogv1", v)
+		}
+	})
+
+	t.Run("an exposed bazaar branch-format is flagged", func(t *testing.T) {
+		res := runVCSModule(t, bzr, 200, bzrFormat)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a bazaar finding")
+		}
+		if v := vcsExtract(res, "bzr_format"); v != "Bazaar-NG meta directory, format 1" {
+			t.Errorf("bzr_format=%q, want the meta directory signature", v)
+		}
+	})
+
+	t.Run("a generic sqlite database without svn tables is not flagged", func(t *testing.T) {
+		body := "SQLite format 3\x00" + strings.Repeat("\x00", 80) +
+			"CREATE TABLE users (id INTEGER, name TEXT, email TEXT);"
+		if res := runVCSModule(t, svn, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a generic sqlite db should not match svn, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a generic sqlite with a nodes table is not an svn working copy", func(t *testing.T) {
+		body := "SQLite format 3\x00" + strings.Repeat("\x00", 80) +
+			"CREATE TABLE NODES (id INTEGER PRIMARY KEY, parent INTEGER, label TEXT);"
+		if res := runVCSModule(t, svn, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a generic nodes table should not match svn, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an svn magic that is not at byte zero is not flagged", func(t *testing.T) {
+		body := "<!DOCTYPE html><html><body><pre>SQLite format 3 WCROOT REPOSITORY</pre></body></html>"
+		if res := runVCSModule(t, svn, 200, body); len(res.Findings) > 0 {
+			t.Errorf("an unanchored magic should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a page naming mercurial without the requires format is not flagged", func(t *testing.T) {
+		body := "this project uses mercurial for distributed version control"
+		if res := runVCSModule(t, hg, 200, body); len(res.Findings) > 0 {
+			t.Errorf("prose naming mercurial should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an html page demonstrating hg requires is not a leak", func(t *testing.T) {
+		body := "<!DOCTYPE html><html><body><pre>revlogv1\nstore\ndotencode</pre></body></html>"
+		if res := runVCSModule(t, hg, 200, body); len(res.Findings) > 0 {
+			t.Errorf("an html hg tutorial should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a bazaar marketplace page is not a repository", func(t *testing.T) {
+		body := "Welcome to the Bazaar, the finest open air marketplace in town"
+		if res := runVCSModule(t, bzr, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a marketplace page should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an html page demonstrating bzr branch-format is not a leak", func(t *testing.T) {
+		body := "<!DOCTYPE html><html><body><pre>Bazaar-NG meta directory, format 1</pre></body></html>"
+		if res := runVCSModule(t, bzr, 200, body); len(res.Findings) > 0 {
+			t.Errorf("an html bzr tutorial should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{svn, hg, bzr} {
+			if res := runVCSModule(t, file, 200, "ok"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{svn, hg, bzr} {
+			if res := runVCSModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/recon/bazaar-exposure.yaml
+++ b/modules/recon/bazaar-exposure.yaml
@@ -1,0 +1,47 @@
+# Exposed Bazaar Repository Detection Module
+
+id: bazaar-exposure
+info:
+  name: Exposed Bazaar Repository
+  author: sif
+  severity: high
+  description: Detects an exposed .bzr repository through its branch-format file that may leak source code
+  tags: [bazaar, bzr, exposure, source-code, misconfiguration]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/.bzr/branch-format"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "Bazaar"
+
+    - type: word
+      part: body
+      words:
+        - "meta directory"
+
+    - type: word
+      part: body
+      negative: true
+      condition: or
+      words:
+        - "<!DOCTYPE"
+        - "<html"
+
+  extractors:
+    - type: regex
+      name: bzr_format
+      part: body
+      regex:
+        - '(Bazaar[^\r\n]*)'
+      group: 1

--- a/modules/recon/mercurial-exposure.yaml
+++ b/modules/recon/mercurial-exposure.yaml
@@ -1,0 +1,47 @@
+# Exposed Mercurial Repository Detection Module
+
+id: mercurial-exposure
+info:
+  name: Exposed Mercurial Repository
+  author: sif
+  severity: high
+  description: Detects an exposed .hg repository through its requires file that may leak source code
+  tags: [mercurial, hg, exposure, source-code, misconfiguration]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/.hg/requires"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      condition: or
+      words:
+        - "revlogv1"
+        - "dotencode"
+        - "fncache"
+        - "generaldelta"
+        - "sparserevlog"
+
+    - type: word
+      part: body
+      negative: true
+      condition: or
+      words:
+        - "<!DOCTYPE"
+        - "<html"
+
+  extractors:
+    - type: regex
+      name: hg_requirement
+      part: body
+      regex:
+        - '(revlogv1|dotencode|fncache|generaldelta|sparserevlog|store|treemanifest)'
+      group: 1

--- a/modules/recon/svn-exposure.yaml
+++ b/modules/recon/svn-exposure.yaml
@@ -1,0 +1,41 @@
+# Exposed Subversion Repository Detection Module
+
+id: svn-exposure
+info:
+  name: Exposed Subversion Repository
+  author: sif
+  severity: high
+  description: Detects an exposed .svn working copy database that may leak source code
+  tags: [svn, subversion, exposure, source-code, misconfiguration]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/.svn/wc.db"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - '^SQLite format 3\x00'
+
+    - type: word
+      part: body
+      condition: or
+      words:
+        - "WCROOT"
+        - "PRISTINE"
+
+  extractors:
+    - type: regex
+      name: svn_repository
+      part: body
+      regex:
+        - '((?:svn\+ssh|svn|https?|file)://[^\x00\s"]+)'
+      group: 1


### PR DESCRIPTION
`modules/recon/svn-exposure.yaml` flags an exposed `.svn` working copy through the `wc.db`
sqlite header anchored at the first byte paired with a `WCROOT` or `PRISTINE` table name, so a
generic sqlite database (or an html page embedding the magic) is not reported, then extracts the
repository url. `modules/recon/mercurial-exposure.yaml` flags an exposed `.hg` repository on the
revlog format requirements the `requires` file lists (`revlogv1`, `dotencode`, `fncache`), so
prose naming mercurial or an html tutorial showing the format is not reported, then extracts the
requirement. `modules/recon/bazaar-exposure.yaml` flags an exposed `.bzr` repository on its
`Bazaar` `meta directory` branch-format signature, so a marketplace page that merely names a
bazaar is not reported, then extracts the format.

build/vet/lint clean, `go test ./internal/modules/` green (the three modules end to end via
`ExecuteHTTPModule`, real-hit and near-miss cases).
