### PR TITLE
feat(modules): add metabase, zeppelin and jupyter exposure modules

### DIFF
--- a/internal/modules/analytics_ui_exposure_test.go
+++ b/internal/modules/analytics_ui_exposure_test.go
@@ -1,0 +1,164 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dropalldatabases/sif/internal/modules"
+)
+
+func runAnalyticsModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func analyticsExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestAnalyticsUIExposureModules(t *testing.T) {
+	const metabase = "../../modules/recon/metabase-api-exposure.yaml"
+	const zeppelin = "../../modules/recon/zeppelin-api-exposure.yaml"
+	const jupyter = "../../modules/recon/jupyter-api-exposure.yaml"
+
+	metabaseProps := `{"engines":{"postgres":{"driver-name":"PostgreSQL"}},` +
+		`"setup-token":"245f5f7c-8f0b-4c20-9a1e-6b2d7e1f0a33","anon-tracking-enabled":true,` +
+		`"available-locales":[["en","English"]],"password-complexity":{"total":6},` +
+		`"version":{"date":"2023-10-01","tag":"v0.47.2","branch":"release-x.47.x","hash":"abc1234"}}`
+
+	zeppelinVersion := `{"status":"OK","message":"Zeppelin version",` +
+		`"body":{"version":"0.10.1","git-commit-id":"a1b2c3d4e5","git-timestamp":"2022-01-15 10:00:00"}}`
+
+	jupyterStatus := `{"started":"2024-01-01T00:00:00.000000Z",` +
+		`"last_activity":"2024-01-01T01:23:45.000000Z","connections":2,"kernels":3}`
+
+	t.Run("an exposed metabase properties api is flagged and versioned", func(t *testing.T) {
+		res := runAnalyticsModule(t, metabase, 200, metabaseProps)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a metabase finding")
+		}
+		if v := analyticsExtract(res, "metabase_version"); v != "v0.47.2" {
+			t.Errorf("metabase_version=%q, want v0.47.2", v)
+		}
+	})
+
+	t.Run("an exposed zeppelin server is flagged and versioned", func(t *testing.T) {
+		res := runAnalyticsModule(t, zeppelin, 200, zeppelinVersion)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a zeppelin finding")
+		}
+		if v := analyticsExtract(res, "zeppelin_version"); v != "0.10.1" {
+			t.Errorf("zeppelin_version=%q, want 0.10.1", v)
+		}
+	})
+
+	t.Run("an exposed jupyter status api is flagged with the kernel count", func(t *testing.T) {
+		res := runAnalyticsModule(t, jupyter, 200, jupyterStatus)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a jupyter finding")
+		}
+		if v := analyticsExtract(res, "jupyter_active_kernels"); v != "3" {
+			t.Errorf("jupyter_active_kernels=%q, want 3", v)
+		}
+	})
+
+	t.Run("a live metabase token without the tracking setting is not flagged", func(t *testing.T) {
+		body := `{"setup-token":"245f5f7c-8f0b-4c20-9a1e-6b2d7e1f0a33","name":"app"}`
+		if res := runAnalyticsModule(t, metabase, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a setup token alone should not match metabase, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a metabase tracking setting without a setup token is not flagged", func(t *testing.T) {
+		body := `{"anon-tracking-enabled":true,"name":"app"}`
+		if res := runAnalyticsModule(t, metabase, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a tracking setting alone should not match metabase, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a patched metabase with a null setup token is not flagged", func(t *testing.T) {
+		body := `{"setup-token":null,"anon-tracking-enabled":true,` +
+			`"version":{"tag":"v0.47.2"}}`
+		if res := runAnalyticsModule(t, metabase, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a null setup token should not match metabase, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a zeppelin banner without a git commit id is not flagged", func(t *testing.T) {
+		body := `{"status":"OK","message":"Zeppelin version","body":{}}`
+		if res := runAnalyticsModule(t, zeppelin, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a banner alone should not match zeppelin, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a git commit id without the zeppelin banner is not flagged", func(t *testing.T) {
+		body := `{"git-commit-id":"a1b2c3d","name":"app"}`
+		if res := runAnalyticsModule(t, zeppelin, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a commit id alone should not match zeppelin, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a jupyter status without a kernels field is not flagged", func(t *testing.T) {
+		body := `{"started":"2024-01-01T00:00:00Z","last_activity":"2024-01-01T01:00:00Z","connections":2}`
+		if res := runAnalyticsModule(t, jupyter, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a status without kernels should not match jupyter, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a jupyter status without a connections field is not flagged", func(t *testing.T) {
+		body := `{"started":"2024-01-01T00:00:00Z","last_activity":"2024-01-01T01:00:00Z","kernels":3}`
+		if res := runAnalyticsModule(t, jupyter, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a status without connections should not match jupyter, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a generic version json is not an analytics service", func(t *testing.T) {
+		body := `{"version":"1.0.0","name":"app"}`
+		for _, file := range []string{metabase, zeppelin, jupyter} {
+			if res := runAnalyticsModule(t, file, 200, body); len(res.Findings) > 0 {
+				t.Errorf("%s: a generic version should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{metabase, zeppelin, jupyter} {
+			if res := runAnalyticsModule(t, file, 200, "ok"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{metabase, zeppelin, jupyter} {
+			if res := runAnalyticsModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/recon/jupyter-api-exposure.yaml
+++ b/modules/recon/jupyter-api-exposure.yaml
@@ -1,0 +1,44 @@
+# Jupyter Server API Exposure Detection Module
+
+id: jupyter-api-exposure
+info:
+  name: Jupyter Server API Exposure
+  author: sif
+  severity: high
+  description: Detects a Jupyter server whose status api answers without authentication
+  tags: [jupyter, notebook, api, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/status"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"last_activity\""
+
+    - type: word
+      part: body
+      words:
+        - "\"connections\""
+
+    - type: word
+      part: body
+      words:
+        - "\"kernels\""
+
+  extractors:
+    - type: regex
+      name: jupyter_active_kernels
+      part: body
+      regex:
+        - '"kernels"\s*:\s*([0-9]+)'
+      group: 1

--- a/modules/recon/metabase-api-exposure.yaml
+++ b/modules/recon/metabase-api-exposure.yaml
@@ -1,0 +1,39 @@
+# Metabase Setup Token Exposure Detection Module
+
+id: metabase-api-exposure
+info:
+  name: Metabase Setup Token Exposure
+  author: sif
+  severity: high
+  description: Detects a Metabase instance that exposes a live setup token without authentication
+  tags: [metabase, analytics, api, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/session/properties"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - '"setup-token"\s*:\s*"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
+
+    - type: word
+      part: body
+      words:
+        - "\"anon-tracking-enabled\""
+
+  extractors:
+    - type: regex
+      name: metabase_version
+      part: body
+      regex:
+        - '"version"\s*:\s*\{[^}]*?"tag"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/zeppelin-api-exposure.yaml
+++ b/modules/recon/zeppelin-api-exposure.yaml
@@ -1,0 +1,39 @@
+# Apache Zeppelin API Exposure Detection Module
+
+id: zeppelin-api-exposure
+info:
+  name: Apache Zeppelin API Exposure
+  author: sif
+  severity: medium
+  description: Detects an Apache Zeppelin server that discloses its version and build commit over the anonymous version api
+  tags: [zeppelin, apache, notebook, api, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/version"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "Zeppelin version"
+
+    - type: word
+      part: body
+      words:
+        - "\"git-commit-id\""
+
+  extractors:
+    - type: regex
+      name: zeppelin_version
+      part: body
+      regex:
+        - '"version"\s*:\s*"([^"]+)"'
+      group: 1


### PR DESCRIPTION
`modules/recon/metabase-api-exposure.yaml` flags a metabase instance exposing a live
`setup-token` without auth on `/api/session/properties`, keyed on a non-null token uuid paired
with the `anon-tracking-enabled` setting, then extracts the version tag; a live token is the
pre-auth chain behind `CVE-2023-38646`, and a patched instance reports the token as `null` and is
left alone. `modules/recon/zeppelin-api-exposure.yaml` flags an apache zeppelin server disclosing
its version and build commit over the anonymous `/api/version`, keyed on the `Zeppelin version`
banner paired with the `git-commit-id`, then extracts the version (a version leak rather than an
auth bypass, since the endpoint stays anonymous even on a shiro-secured instance).
`modules/recon/jupyter-api-exposure.yaml` flags a jupyter server whose `/api/status` answers
without a token, keyed on the `last_activity`, `connections` and `kernels` fields, then extracts
the running kernel count.

build/vet/lint clean, `go test ./internal/modules/` green (the three modules end to end via
`ExecuteHTTPModule`, real-hit and near-miss cases).
