### PR TITLE
fix(scan): skip built-in module when its legacy flag already ran

### DIFF
--- a/sif.go
+++ b/sif.go
@@ -647,6 +647,24 @@ func (app *App) Run() error {
 				}
 
 				for _, m := range toRun {
+					switch m.Info().ID {
+					case "nuclei-scan":
+						if app.settings.Nuclei {
+							continue
+						}
+					case "framework-detection":
+						if app.settings.Framework {
+							continue
+						}
+					case "shodan-lookup":
+						if app.settings.Shodan {
+							continue
+						}
+					case "whois-lookup":
+						if app.settings.Whois {
+							continue
+						}
+					}
 					modLog := output.Module(m.Info().ID)
 					modLog.Start()
 					result, err := m.Execute(context.Background(), url, opts)


### PR DESCRIPTION
four built-in go modules (nuclei-scan, framework-detection, shodan-lookup,
whois-lookup) wrap a legacy per-target scan that also has its own flag, so
running -am alongside one of those flags (e.g. -am -nuclei) ran the same
per-target scan twice. skip the wrapper module in the run loop when its flag
already ran. securitytrails-lookup is not deduped: its -securitytrails flag
expands the target list rather than scanning a target, so the module is not a
duplicate of it.
