### PR TITLE
fix(scan): de-duplicate selected modules before running them

### DIFF
--- a/sif.go
+++ b/sif.go
@@ -639,6 +639,16 @@ func (app *App) Run() error {
 					}
 				}
 
+				seen := make(map[string]bool, len(toRun))
+				deduped := make([]modules.Module, 0, len(toRun))
+				for _, m := range toRun {
+					if id := m.Info().ID; !seen[id] {
+						seen[id] = true
+						deduped = append(deduped, m)
+					}
+				}
+				toRun = deduped
+
 				// Execute modules
 				opts := modules.Options{
 					Timeout: app.settings.Timeout,


### PR DESCRIPTION
-mt builds the run list by appending modules.ByTag per tag and -m by appending
each id, neither de-duplicated, so a module matching two requested tags
(nuclei-scan is tagged both vuln and cve, so -mt vuln,cve) or listed twice ran
twice. de-duplicate toRun by module id, preserving first-seen order, before
executing.
