### PR TITLE
ci(pr-bot): run on pull_request_target so fork PRs get labeled

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -1,7 +1,7 @@
 name: pr bot
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 permissions:
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -23,7 +23,6 @@ jobs:
   size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
       - name: label pr size
         uses: actions/github-script@v9
         with:


### PR DESCRIPTION
fork PRs get a read-only token on `pull_request`, so the **label**, **size** and **ci-summary** jobs 403 and the summary check shows red on every external PR.

fix: run on `pull_request_target` (write token, base-repo context), key the concurrency group on the PR number so runs don't collide, and drop the size job's now-unused checkout. none of these jobs check out or run PR code, they only hit the github API with the event payload, so this is the safe `pull_request_target` labeler pattern (no untrusted-code execution).

supersedes #146 (same fix by @TBX3D, which conflicted after the checkout bump in #143).