### PR TITLE
feat(httpx): retry 429 and 503 with Retry-After backoff

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ type Settings struct {
 	Header            goflags.StringSlice // custom request headers ("Key: Value")
 	Cookie            string
 	RateLimit         int
+	MaxRetries        int    // -max-retries: retries on 429/503 (0 = off)
 	Notify            bool   // -notify: ship findings to configured providers
 	NotifySeverity    string // -notify-severity: minimum severity to send (info..critical)
 	NotifyConfig      string // -notify-config: path to a notify-compatible yaml file
@@ -178,6 +179,7 @@ func registerFlags(settings *Settings) *goflags.FlagSet {
 		flagSet.StringSliceVarP(&settings.Header, "header", "H", nil, "Custom header to send (repeatable or comma-separated, \"Key: Value\")", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.StringVar(&settings.Cookie, "cookie", "", "Cookie header to send with every request"),
 		flagSet.IntVar(&settings.RateLimit, "rate-limit", 0, "Max requests per second (0 = unlimited)"),
+		flagSet.IntVar(&settings.MaxRetries, "max-retries", 2, "Retries on 429/503 with Retry-After backoff (0 = off)"),
 	)
 
 	flagSet.CreateGroup("output", "Output",

--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -16,11 +16,13 @@
 package httpx
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -74,6 +76,8 @@ type Options struct {
 	Cookie    string
 	UserAgent string
 	RateLimit int
+	// MaxRetries is how many 429/503 responses to retry with backoff (0 = off).
+	MaxRetries int
 	// Threads is the scan worker count; it sizes the per-host idle pool so
 	// concurrent workers hitting one target reuse conns instead of dialing fresh.
 	Threads int
@@ -107,11 +111,12 @@ func Configure(opts Options) error {
 	}
 
 	rt := &roundTripper{
-		base:      base,
-		headers:   headers,
-		cookie:    opts.Cookie,
-		userAgent: opts.UserAgent,
-		limiter:   limiter,
+		base:       base,
+		headers:    headers,
+		cookie:     opts.Cookie,
+		userAgent:  opts.UserAgent,
+		limiter:    limiter,
+		maxRetries: opts.MaxRetries,
 	}
 
 	mu.Lock()
@@ -226,20 +231,15 @@ func parseHeaders(raw []string) (map[string]string, error) {
 
 // roundTripper paces and decorates each request before delegating to base.
 type roundTripper struct {
-	base      *http.Transport
-	headers   map[string]string
-	cookie    string
-	userAgent string
-	limiter   *rate.Limiter
+	base       *http.Transport
+	headers    map[string]string
+	cookie     string
+	userAgent  string
+	limiter    *rate.Limiter
+	maxRetries int
 }
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if rt.limiter != nil {
-		if err := rt.limiter.Wait(req.Context()); err != nil {
-			return nil, fmt.Errorf("rate limiter: %w", err)
-		}
-	}
-
 	// only set what the caller hasn't already; a scanner that explicitly sets a
 	// header (e.g. an api key) must win over the global default.
 	for key, value := range rt.headers {
@@ -254,5 +254,101 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Set("User-Agent", rt.userAgent)
 	}
 
-	return rt.base.RoundTrip(req)
+	for attempt := 0; ; attempt++ {
+		if rt.limiter != nil {
+			if err := rt.limiter.Wait(req.Context()); err != nil {
+				return nil, fmt.Errorf("rate limiter: %w", err)
+			}
+		}
+
+		resp, err := rt.base.RoundTrip(req)
+		if err != nil || attempt >= rt.maxRetries || !retryableStatus(resp.StatusCode) {
+			return resp, err
+		}
+
+		// back off and retry, unless the body can't be replayed.
+		if !rewind(req) {
+			return resp, nil
+		}
+		wait := retryAfter(resp, attempt)
+		DrainClose(resp)
+
+		if err := sleepCtx(req.Context(), wait); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func retryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable
+}
+
+const (
+	retryAfterCap    = 20 * time.Second
+	retryBackoffBase = 500 * time.Millisecond
+	// clamp the shift so a large -max-retries can't overflow the duration.
+	retryBackoffMaxShift = 16
+)
+
+// retryAfter honors a Retry-After header (delta-seconds or HTTP-date) and
+// otherwise falls back to capped exponential backoff.
+func retryAfter(resp *http.Response, attempt int) time.Duration {
+	if v := strings.TrimSpace(resp.Header.Get("Retry-After")); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+			return capDuration(time.Duration(secs) * time.Second)
+		}
+		if t, err := http.ParseTime(v); err == nil {
+			return capDuration(time.Until(t))
+		}
+	}
+	shift := attempt
+	if shift > retryBackoffMaxShift {
+		shift = retryBackoffMaxShift
+	}
+	return capDuration(retryBackoffBase << shift)
+}
+
+// capDuration clamps d to [0, retryAfterCap].
+func capDuration(d time.Duration) time.Duration {
+	switch {
+	case d < 0:
+		return 0
+	case d > retryAfterCap:
+		return retryAfterCap
+	default:
+		return d
+	}
+}
+
+// rewind restores req.Body for a resend. Only a GetBody-backed body (set by
+// net/http for the in-memory bodies sif uses) is replayable; a nil or NoBody
+// request needs nothing, anything else can't be retried.
+func rewind(req *http.Request) bool {
+	if req.Body == nil || req.Body == http.NoBody {
+		return true
+	}
+	if req.GetBody == nil {
+		return false
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return false
+	}
+	req.Body = body
+	return true
+}
+
+// sleepCtx waits for d or until ctx is cancelled, whichever comes first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -488,4 +489,229 @@ func resetBench() {
 	mu.Lock()
 	configured = nil
 	mu.Unlock()
+}
+
+// retrySequenceServer serves codes[n] on the n-th hit, repeating the last once
+// the slice runs out; retryable codes carry Retry-After: 0 to keep tests fast.
+func retrySequenceServer(t *testing.T, hits *atomic.Int64, codes ...int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := int(hits.Add(1)) - 1
+		code := codes[len(codes)-1]
+		if n < len(codes) {
+			code = codes[n]
+		}
+		if code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable {
+			w.Header().Set("Retry-After", "0")
+		}
+		w.WriteHeader(code)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// getStatus performs a GET and returns the final status code the caller sees.
+func getStatus(t *testing.T, client *http.Client, url string) int {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+func TestRetryRecoversAfter429(t *testing.T) {
+	resetConfig(t)
+
+	var hits atomic.Int64
+	srv := retrySequenceServer(t, &hits, http.StatusTooManyRequests, http.StatusOK)
+	if err := Configure(Options{MaxRetries: 2}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if code := getStatus(t, Client(5*time.Second), srv.URL); code != http.StatusOK {
+		t.Errorf("status = %d, want 200 after retry", code)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Errorf("server hits = %d, want 2 (initial + one retry)", got)
+	}
+}
+
+func TestRetryRecoversAfter503(t *testing.T) {
+	resetConfig(t)
+
+	var hits atomic.Int64
+	srv := retrySequenceServer(t, &hits, http.StatusServiceUnavailable, http.StatusOK)
+	if err := Configure(Options{MaxRetries: 2}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if code := getStatus(t, Client(5*time.Second), srv.URL); code != http.StatusOK {
+		t.Errorf("status = %d, want 200 after retry", code)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Errorf("server hits = %d, want 2", got)
+	}
+}
+
+func TestRetryDisabled(t *testing.T) {
+	resetConfig(t)
+
+	var hits atomic.Int64
+	srv := retrySequenceServer(t, &hits, http.StatusTooManyRequests, http.StatusOK)
+	if err := Configure(Options{MaxRetries: 0}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if code := getStatus(t, Client(5*time.Second), srv.URL); code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 with retries off", code)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("server hits = %d, want 1 (no retry)", got)
+	}
+}
+
+func TestRetryExhausted(t *testing.T) {
+	resetConfig(t)
+
+	var hits atomic.Int64
+	srv := retrySequenceServer(t, &hits, http.StatusTooManyRequests) // always 429
+	if err := Configure(Options{MaxRetries: 2}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if code := getStatus(t, Client(5*time.Second), srv.URL); code != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429 after exhausting retries", code)
+	}
+	if got := hits.Load(); got != 3 {
+		t.Errorf("server hits = %d, want 3 (initial + 2 retries)", got)
+	}
+}
+
+func TestRetryIgnoresNonRetryableStatus(t *testing.T) {
+	resetConfig(t)
+
+	var hits atomic.Int64
+	srv := retrySequenceServer(t, &hits, http.StatusInternalServerError, http.StatusOK)
+	if err := Configure(Options{MaxRetries: 2}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if code := getStatus(t, Client(5*time.Second), srv.URL); code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (not retried)", code)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("server hits = %d, want 1 (500 not retried)", got)
+	}
+}
+
+func TestRetryReplaysRequestBody(t *testing.T) {
+	resetConfig(t)
+
+	var hits atomic.Int64
+	var bmu sync.Mutex
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bmu.Lock()
+		bodies = append(bodies, string(body))
+		bmu.Unlock()
+		if hits.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := Configure(Options{MaxRetries: 2}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := Client(5 * time.Second).Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after body replay", resp.StatusCode)
+	}
+
+	bmu.Lock()
+	defer bmu.Unlock()
+	if len(bodies) != 2 {
+		t.Fatalf("server saw %d requests, want 2", len(bodies))
+	}
+	for i, body := range bodies {
+		if body != "payload" {
+			t.Errorf("body[%d] = %q, want %q (rewind dropped the body)", i, body, "payload")
+		}
+	}
+}
+
+func TestRetryAfterHeader(t *testing.T) {
+	noHeader := &http.Response{Header: http.Header{}}
+	if got := retryAfter(noHeader, 0); got != retryBackoffBase {
+		t.Errorf("missing header: attempt 0 = %v, want %v", got, retryBackoffBase)
+	}
+	if got := retryAfter(noHeader, 1); got != 2*retryBackoffBase {
+		t.Errorf("missing header: attempt 1 = %v, want %v", got, 2*retryBackoffBase)
+	}
+	if got := retryAfter(noHeader, 1000); got != retryAfterCap {
+		t.Errorf("missing header: attempt 1000 = %v, want cap %v", got, retryAfterCap)
+	}
+
+	withSeconds := func(v string) *http.Response {
+		return &http.Response{Header: http.Header{"Retry-After": {v}}}
+	}
+	if got := retryAfter(withSeconds("3"), 0); got != 3*time.Second {
+		t.Errorf("Retry-After 3 = %v, want 3s", got)
+	}
+	if got := retryAfter(withSeconds("0"), 5); got != 0 {
+		t.Errorf("Retry-After 0 = %v, want 0", got)
+	}
+	if got := retryAfter(withSeconds("9999"), 0); got != retryAfterCap {
+		t.Errorf("Retry-After 9999 = %v, want cap %v", got, retryAfterCap)
+	}
+	if got := retryAfter(withSeconds("soon"), 0); got != retryBackoffBase {
+		t.Errorf("Retry-After junk = %v, want backoff %v", got, retryBackoffBase)
+	}
+
+	future := time.Now().Add(5 * time.Second).UTC().Format(http.TimeFormat)
+	if got := retryAfter(withSeconds(future), 0); got <= 0 || got > 5*time.Second {
+		t.Errorf("Retry-After http-date = %v, want (0, 5s]", got)
+	}
+}
+
+func TestCapDuration(t *testing.T) {
+	cases := []struct{ in, want time.Duration }{
+		{-time.Second, 0},
+		{0, 0},
+		{5 * time.Second, 5 * time.Second},
+		{retryAfterCap, retryAfterCap},
+		{retryAfterCap + time.Second, retryAfterCap},
+	}
+	for _, c := range cases {
+		if got := capDuration(c.in); got != c.want {
+			t.Errorf("capDuration(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSleepCtxCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := sleepCtx(ctx, time.Hour); err == nil {
+		t.Error("sleepCtx on a cancelled context should return its error, not block")
+	}
 }

--- a/sif.go
+++ b/sif.go
@@ -278,11 +278,12 @@ func (app *App) Run() error {
 	// before any scanner runs. a bad proxy/header shouldn't kill the run -
 	// scanners fall back to a plain client if this fails.
 	if err := httpx.Configure(httpx.Options{
-		Proxy:     app.settings.Proxy,
-		Headers:   app.settings.Header,
-		Cookie:    app.settings.Cookie,
-		RateLimit: app.settings.RateLimit,
-		Threads:   app.settings.Threads,
+		Proxy:      app.settings.Proxy,
+		Headers:    app.settings.Header,
+		Cookie:     app.settings.Cookie,
+		RateLimit:  app.settings.RateLimit,
+		MaxRetries: app.settings.MaxRetries,
+		Threads:    app.settings.Threads,
 	}); err != nil {
 		log.Warnf("http client config failed, continuing with defaults: %v", err)
 	}


### PR DESCRIPTION
the shared transport paced outbound requests but ignored a server
asking it to slow down, so a 429 or 503 came straight back as a failed
probe. back off and retry both through the one chokepoint every scanner
shares, honoring Retry-After (delta-seconds or http-date) and falling
back to capped exponential backoff.

gated behind -max-retries (default 2, 0 disables). bodyless GETs and
GetBody-backed requests replay safely; anything else is returned as-is.
