### PR TITLE
test(modules): fix favicon_test checkMatchers arity

### DIFF
--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -142,7 +142,7 @@ func TestCheckMatcherFaviconNegative(t *testing.T) {
 	signed := int64(fingerprint.FaviconHash(faviconFixture))
 	matchers := []Matcher{{Type: "favicon", Hash: []int64{signed}, Negative: true}}
 	resp := fakeResponse(t, 200, nil)
-	if checkMatchers(matchers, resp, string(faviconFixture)) {
+	if checkMatchers(matchers, "", resp, string(faviconFixture)) {
 		t.Error("negative favicon matcher should not match its own hash")
 	}
 }


### PR DESCRIPTION
#189 (matchers-condition) added a `condition` param to `checkMatchers`; #183's favicon test still called the 3-arg form. each passed CI alone but together they broke main's build. pass `""` (default and-condition) to fix.