### PR TITLE
fix(modules): match favicon test to the matchers-condition signature

### DIFF
--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -142,7 +142,7 @@ func TestCheckMatcherFaviconNegative(t *testing.T) {
 	signed := int64(fingerprint.FaviconHash(faviconFixture))
 	matchers := []Matcher{{Type: "favicon", Hash: []int64{signed}, Negative: true}}
 	resp := fakeResponse(t, 200, nil)
-	if checkMatchers(matchers, resp, string(faviconFixture)) {
+	if checkMatchers(matchers, "", resp, string(faviconFixture)) {
 		t.Error("negative favicon matcher should not match its own hash")
 	}
 }


### PR DESCRIPTION
#189 gave checkMatchers a condition parameter; the favicon test added in
#183 still called it with the old three-argument form, so internal/modules
fails to compile on main. pass the empty condition the other matcher tests
already use.
