### PR TITLE
test(scan): fix integration_test SQL arity

### DIFF
--- a/internal/scan/integration_test.go
+++ b/internal/scan/integration_test.go
@@ -181,7 +181,7 @@ func TestIntegrationSQL(t *testing.T) {
 	srv := newVulnApp()
 	defer srv.Close()
 
-	result, err := SQL(srv.URL, 5*time.Second, 5, "")
+	result, err := SQL(srv.URL, 5*time.Second, 5, "", false)
 	if err != nil {
 		t.Fatalf("SQL: %v", err)
 	}


### PR DESCRIPTION
#180 added `calibrate bool` to `SQL()`; the integration-tagged test (`-tags=integration`, not built in normal CI) still called the 4-arg form. one-line fix.