### PR TITLE
docs(readme): fix invalid discord shield invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you like the project, but don't have time to contribute, that's okay too! Her
 
 ## Reporting issues
 
-If you believe you've found a bug, or you have a new feature to request, please hop on the [Discord server](https://discord.com/invite/sifcli) first to discuss it.  
+If you believe you've found a bug, or you have a new feature to request, please hop on the [Discord server](https://discord.gg/Yksy9J2BvE) first to discuss it.
 This way, if it's an easy fix, we could help you solve it more quickly, and if it's a feature request we could workshop it together into something more mature.
 
 When opening an issue, please use the search tool and make sure that the issue has not been discussed before. In the case of a bug report, run sif with the `-d/-debug` flag for full debug logs.

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ go test ./...
 
 join our discord for support, feature discussions, and pentesting tips:
 
-[![discord](https://img.shields.io/badge/join%20our%20discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/sifcli)
+[![discord](https://img.shields.io/badge/join%20our%20discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/Yksy9J2BvE)
 
 ## contributors
 


### PR DESCRIPTION
- Replaced the invalid Discord invite link badge to the correct one from the top of the README