### PR TITLE
style: apply gofmt to source tree

### DIFF
--- a/internal/finding/finding.go
+++ b/internal/finding/finding.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/vmfunc/sif/internal/modules"
 	"github.com/vmfunc/sif/internal/scan"
 	"github.com/vmfunc/sif/internal/scan/frameworks"
 	"github.com/vmfunc/sif/internal/scan/js"
-	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
 
 // Finding is the normalized shape every scanner result collapses to. one

--- a/internal/finding/finding_test.go
+++ b/internal/finding/finding_test.go
@@ -16,13 +16,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/projectdiscovery/nuclei/v3/pkg/model"
+	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/vmfunc/sif/internal/modules"
 	"github.com/vmfunc/sif/internal/scan"
 	"github.com/vmfunc/sif/internal/scan/frameworks"
 	"github.com/vmfunc/sif/internal/scan/js"
-	"github.com/projectdiscovery/nuclei/v3/pkg/model"
-	"github.com/projectdiscovery/nuclei/v3/pkg/model/types/severity"
-	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
 
 // scanResultType mirrors the minimal interface the scan packages implement; the

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -93,7 +93,7 @@ type Matcher struct {
 	Status    []int    `yaml:"status,omitempty"`
 	Size      []int    `yaml:"size,omitempty"`
 	Hash      []int64  `yaml:"hash,omitempty"` // favicon: shodan mmh3 hashes (signed or unsigned)
-	Condition string   `yaml:"condition"` // and, or
+	Condition string   `yaml:"condition"`      // and, or
 	Negative  bool     `yaml:"negative"`
 }
 

--- a/internal/nuclei/format/format.go
+++ b/internal/nuclei/format/format.go
@@ -13,8 +13,8 @@
 package format
 
 import (
-	"github.com/vmfunc/sif/internal/styles"
 	nucleiout "github.com/projectdiscovery/nuclei/v3/pkg/output"
+	"github.com/vmfunc/sif/internal/styles"
 )
 
 func FormatLine(event *nucleiout.ResultEvent) string {

--- a/internal/scan/dork.go
+++ b/internal/scan/dork.go
@@ -25,11 +25,11 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
+	googlesearch "github.com/rocketlaunchr/google-search"
 	"github.com/vmfunc/sif/internal/httpx"
 	"github.com/vmfunc/sif/internal/logger"
 	"github.com/vmfunc/sif/internal/output"
 	"github.com/vmfunc/sif/internal/pool"
-	googlesearch "github.com/rocketlaunchr/google-search"
 )
 
 const (

--- a/internal/scan/js/frameworks/next.go
+++ b/internal/scan/js/frameworks/next.go
@@ -30,8 +30,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/vmfunc/sif/internal/httpx"
 	urlutil "github.com/projectdiscovery/utils/url"
+	"github.com/vmfunc/sif/internal/httpx"
 )
 
 // nextPagesRegex matches JavaScript file references in Next.js build manifest.

--- a/internal/scan/js/scan.go
+++ b/internal/scan/js/scan.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/antchfx/htmlquery"
 	charmlog "github.com/charmbracelet/log"
+	urlutil "github.com/projectdiscovery/utils/url"
 	"github.com/vmfunc/sif/internal/httpx"
 	"github.com/vmfunc/sif/internal/output"
 	"github.com/vmfunc/sif/internal/scan/js/frameworks"
-	urlutil "github.com/projectdiscovery/utils/url"
 )
 
 type JavascriptScanResult struct {

--- a/internal/scan/nuclei.go
+++ b/internal/scan/nuclei.go
@@ -19,11 +19,11 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
+	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
+	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 	"github.com/vmfunc/sif/internal/nuclei/format"
 	"github.com/vmfunc/sif/internal/nuclei/templates"
 	sifoutput "github.com/vmfunc/sif/internal/output"
-	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
-	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
 
 func Nuclei(url string, timeout time.Duration, threads int, logdir string) ([]output.ResultEvent, error) {

--- a/internal/scan/whois.go
+++ b/internal/scan/whois.go
@@ -14,9 +14,9 @@ package scan
 
 import (
 	"github.com/charmbracelet/log"
+	"github.com/likexian/whois"
 	"github.com/vmfunc/sif/internal/logger"
 	"github.com/vmfunc/sif/internal/output"
-	"github.com/likexian/whois"
 )
 
 func Whois(url string, logdir string) {


### PR DESCRIPTION
## Summary

Ran `gofmt -w .` accross the repo to fix formatting drift.

Mechanical `gofmt -w .` only. No functional or behavioural changes.

CONTRIBUTING.md requires gofmt-clean code; these files had slipped.