### PR TITLE
feat(modules): detect exposed llm chat frontends

### DIFF
--- a/internal/modules/llm_ui_exposure_test.go
+++ b/internal/modules/llm_ui_exposure_test.go
@@ -1,0 +1,204 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+func runUIExposureModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func uiExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestLLMUIExposureModules(t *testing.T) {
+	const openWebUI = "../../modules/recon/open-webui-exposure.yaml"
+	const librechat = "../../modules/recon/librechat-exposure.yaml"
+	const nextchat = "../../modules/recon/nextchat-config-exposure.yaml"
+	const anythingllm = "../../modules/recon/anythingllm-exposure.yaml"
+
+	openWebUIConfig := `{"status":true,"name":"Open WebUI","version":"0.6.15","default_locale":"",` +
+		`"oauth":{"providers":{}},"features":{"auth":false,"auth_trusted_header":false,` +
+		`"enable_ldap":false,"enable_signup":true,"enable_login_form":true,"enable_websocket":true}}`
+
+	librechatConfig := `{"appTitle":"LibreChat","serverDomain":"https://chat.example.com",` +
+		`"emailLoginEnabled":true,"registrationEnabled":true,"socialLogins":["google","github"]}`
+
+	nextchatConfig := `{"needCode":false,"hideUserApiKey":false,"disableGPT4":false,` +
+		`"hideBalanceQuery":true,"disableFastLink":false,"customModels":"","defaultModel":"gpt-4o-mini",` +
+		`"visionModels":""}`
+
+	anythingllmSetup := `{"results":{"RequiresAuth":false,"MultiUserMode":false,"EmbeddingEngine":"native",` +
+		`"VectorDB":"lancedb","LLMProvider":"openai","LLMModel":"gpt-4o","WhisperProvider":"local"}}`
+
+	t.Run("an open webui with auth disabled is flagged with its version", func(t *testing.T) {
+		res := runUIExposureModule(t, openWebUI, 200, openWebUIConfig)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an open webui finding")
+		}
+		if v := uiExtract(res, "open_webui_version"); v != "0.6.15" {
+			t.Errorf("open_webui_version=%q, want 0.6.15", v)
+		}
+	})
+
+	t.Run("a rebranded open webui with auth disabled is still flagged", func(t *testing.T) {
+		body := `{"status":true,"name":"Acme AI Portal","version":"0.6.15",` +
+			`"features":{"auth":false,"auth_trusted_header":false,"enable_signup":true}}`
+		res := runUIExposureModule(t, openWebUI, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a finding for a rebranded open webui")
+		}
+		if v := uiExtract(res, "open_webui_version"); v != "0.6.15" {
+			t.Errorf("open_webui_version=%q, want 0.6.15", v)
+		}
+	})
+
+	t.Run("a librechat with open registration is flagged with its title", func(t *testing.T) {
+		res := runUIExposureModule(t, librechat, 200, librechatConfig)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a librechat finding")
+		}
+		if v := uiExtract(res, "librechat_title"); v != "LibreChat" {
+			t.Errorf("librechat_title=%q, want LibreChat", v)
+		}
+	})
+
+	t.Run("an open webui with auth enabled is not flagged", func(t *testing.T) {
+		body := `{"status":true,"name":"Open WebUI","version":"0.6.15",` +
+			`"features":{"auth":true,"auth_trusted_header":false,"enable_signup":true}}`
+		if res := runUIExposureModule(t, openWebUI, 200, body); len(res.Findings) > 0 {
+			t.Errorf("an auth-enabled open webui should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an open webui auth_trusted_header false does not satisfy the auth regex", func(t *testing.T) {
+		body := `{"status":true,"name":"Open WebUI","version":"0.6.15",` +
+			`"features":{"auth":true,"auth_trusted_header":false}}`
+		if res := runUIExposureModule(t, openWebUI, 200, body); len(res.Findings) > 0 {
+			t.Errorf("auth_trusted_header false should not match the auth regex, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a librechat with registration disabled is not flagged", func(t *testing.T) {
+		body := `{"appTitle":"LibreChat","emailLoginEnabled":true,"registrationEnabled":false,"socialLogins":[]}`
+		if res := runUIExposureModule(t, librechat, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a closed-registration librechat should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an unrelated app with open registration is not flagged as librechat", func(t *testing.T) {
+		body := `{"name":"otherapp","registrationEnabled":true}`
+		if res := runUIExposureModule(t, librechat, 200, body); len(res.Findings) > 0 {
+			t.Errorf("an unrelated app should not match librechat, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a nextchat config is flagged and reports its access-code gate", func(t *testing.T) {
+		res := runUIExposureModule(t, nextchat, 200, nextchatConfig)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a nextchat finding")
+		}
+		if v := uiExtract(res, "nextchat_needcode"); v != "false" {
+			t.Errorf("nextchat_needcode=%q, want false", v)
+		}
+	})
+
+	t.Run("a body without needCode is not flagged as nextchat", func(t *testing.T) {
+		body := `{"hideUserApiKey":false,"hideBalanceQuery":true}`
+		if res := runUIExposureModule(t, nextchat, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a body without needCode should not match nextchat, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a body without hideUserApiKey is not flagged as nextchat", func(t *testing.T) {
+		body := `{"needCode":false,"hideBalanceQuery":true}`
+		if res := runUIExposureModule(t, nextchat, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a body without hideUserApiKey should not match nextchat, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a body without hideBalanceQuery is not flagged as nextchat", func(t *testing.T) {
+		body := `{"needCode":false,"hideUserApiKey":false}`
+		if res := runUIExposureModule(t, nextchat, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a body without hideBalanceQuery should not match nextchat, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a code-gated nextchat is not flagged", func(t *testing.T) {
+		body := `{"needCode":true,"hideUserApiKey":false,"hideBalanceQuery":true,"disableGPT4":false}`
+		if res := runUIExposureModule(t, nextchat, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a needCode:true nextchat is access-code gated and should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an anythingllm setup is flagged with its model", func(t *testing.T) {
+		res := runUIExposureModule(t, anythingllm, 200, anythingllmSetup)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an anythingllm finding")
+		}
+		if v := uiExtract(res, "anythingllm_model"); v != "gpt-4o" {
+			t.Errorf("anythingllm_model=%q, want gpt-4o", v)
+		}
+	})
+
+	t.Run("a body without LLMProvider is not flagged as anythingllm", func(t *testing.T) {
+		body := `{"results":{"VectorDB":"lancedb","EmbeddingEngine":"native"}}`
+		if res := runUIExposureModule(t, anythingllm, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a body without LLMProvider should not match anythingllm, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a body without a VectorDB is not flagged as anythingllm", func(t *testing.T) {
+		body := `{"results":{"LLMProvider":"openai","EmbeddingEngine":"native"}}`
+		if res := runUIExposureModule(t, anythingllm, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a body without VectorDB should not match anythingllm, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{openWebUI, librechat, anythingllm, nextchat} {
+			if res := runUIExposureModule(t, file, 200, "ok"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{openWebUI, librechat, anythingllm, nextchat} {
+			if res := runUIExposureModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+}

--- a/modules/recon/anythingllm-exposure.yaml
+++ b/modules/recon/anythingllm-exposure.yaml
@@ -1,0 +1,44 @@
+# AnythingLLM Exposure Detection Module
+
+id: anythingllm-exposure
+info:
+  name: AnythingLLM Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed AnythingLLM instance; its unauthenticated setup endpoint discloses the chosen llm provider and model, the vector database, the embedding engine, and whether multi-user auth is enabled
+  tags: [anythingllm, llm, ai, rag, chat, ui, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/setup-complete"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"LLMProvider\""
+
+    - type: word
+      part: body
+      words:
+        - "\"VectorDB\""
+
+    - type: word
+      part: body
+      words:
+        - "\"EmbeddingEngine\""
+
+  extractors:
+    - type: regex
+      name: anythingllm_model
+      part: body
+      regex:
+        - '"LLMModel"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/librechat-exposure.yaml
+++ b/modules/recon/librechat-exposure.yaml
@@ -1,0 +1,39 @@
+# LibreChat Open Registration Exposure Detection Module
+
+id: librechat-exposure
+info:
+  name: LibreChat Open Registration
+  author: sif
+  severity: low
+  description: Detects a LibreChat instance whose pre-login config advertises open registration, letting anyone create an account and use its configured model providers
+  tags: [librechat, llm, ai, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/config"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"emailLoginEnabled\""
+
+    - type: regex
+      part: body
+      regex:
+        - '"registrationEnabled"\s*:\s*true'
+
+  extractors:
+    - type: regex
+      name: librechat_title
+      part: body
+      regex:
+        - '"appTitle"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/nextchat-config-exposure.yaml
+++ b/modules/recon/nextchat-config-exposure.yaml
@@ -1,0 +1,44 @@
+# NextChat (ChatGPT-Next-Web) Config Exposure Detection Module
+
+id: nextchat-config-exposure
+info:
+  name: NextChat Config Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed NextChat (ChatGPT-Next-Web) deployment whose config endpoint reports no access code set, meaning the proxy relays to provider apis using the operator's keys without any gate
+  tags: [nextchat, chatgpt-next-web, llm, ai, chat, ui, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/config"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: regex
+      part: body
+      regex:
+        - '"needCode"\s*:\s*false'
+
+    - type: word
+      part: body
+      words:
+        - "\"hideUserApiKey\""
+
+    - type: word
+      part: body
+      words:
+        - "\"hideBalanceQuery\""
+
+  extractors:
+    - type: regex
+      name: nextchat_needcode
+      part: body
+      regex:
+        - '"needCode"\s*:\s*(true|false)'
+      group: 1

--- a/modules/recon/open-webui-exposure.yaml
+++ b/modules/recon/open-webui-exposure.yaml
@@ -1,0 +1,39 @@
+# Open WebUI Authentication Disabled Exposure Detection Module
+
+id: open-webui-exposure
+info:
+  name: Open WebUI Authentication Disabled
+  author: sif
+  severity: medium
+  description: Detects an Open WebUI instance running with authentication disabled, leaving the chat ui and its configured model connections open to anyone
+  tags: [open-webui, llm, ai, exposure, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/config"
+
+  matchers:
+    - type: status
+      status:
+        - 200
+
+    - type: word
+      part: body
+      words:
+        - "\"auth_trusted_header\""
+
+    - type: regex
+      part: body
+      regex:
+        - '"auth"\s*:\s*false'
+
+  extractors:
+    - type: regex
+      name: open_webui_version
+      part: body
+      regex:
+        - '"version"\s*:\s*"([^"]+)"'
+      group: 1


### PR DESCRIPTION
add recon modules for unauthenticated chat uis that leak config or allow open signup without a key: open webui, librechat, anythingllm, and nextchat.
