### PR TITLE
feat(modules): add loki, jaeger and zipkin exposure modules

### DIFF
--- a/internal/modules/observability_exposure_test.go
+++ b/internal/modules/observability_exposure_test.go
@@ -1,0 +1,135 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+func runObservabilityModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func observExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestObservabilityExposureModules(t *testing.T) {
+	const loki = "../../modules/recon/loki-api-exposure.yaml"
+	const jaeger = "../../modules/recon/jaeger-query-exposure.yaml"
+	const zipkin = "../../modules/recon/zipkin-exposure.yaml"
+
+	t.Run("an open loki labels response is flagged with a label", func(t *testing.T) {
+		body := `{"status":"success","data":["app","filename","job","namespace","pod"]}`
+		res := runObservabilityModule(t, loki, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a loki finding")
+		}
+		if v := observExtract(res, "loki_label"); v != "app" {
+			t.Errorf("loki_label=%q, want app", v)
+		}
+	})
+
+	t.Run("an open loki with no ingested labels is still flagged", func(t *testing.T) {
+		if res := runObservabilityModule(t, loki, 200, `{"status":"success","data":[]}`); len(res.Findings) == 0 {
+			t.Error("expected a loki finding for an empty-but-open instance")
+		}
+	})
+
+	t.Run("a multi-tenant loki returns 401 and is not flagged", func(t *testing.T) {
+		if res := runObservabilityModule(t, loki, 401, `no org id\n`); len(res.Findings) > 0 {
+			t.Errorf("a 401 from a secured loki should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a non-loki success envelope is not flagged as loki", func(t *testing.T) {
+		if res := runObservabilityModule(t, loki, 200, `{"ok":true,"items":[]}`); len(res.Findings) > 0 {
+			t.Errorf("a body without the loki shape should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a jaeger service list is flagged with a service name", func(t *testing.T) {
+		body := `{"data":["customer","driver","frontend","route"],"total":0,"limit":0,"offset":0,"errors":null}`
+		res := runObservabilityModule(t, jaeger, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a jaeger finding")
+		}
+		if v := observExtract(res, "jaeger_service"); v != "customer" {
+			t.Errorf("jaeger_service=%q, want customer", v)
+		}
+	})
+
+	t.Run("a generic pagination envelope without errors is not flagged as jaeger", func(t *testing.T) {
+		body := `{"data":["a","b"],"total":2,"limit":10,"offset":0}`
+		if res := runObservabilityModule(t, jaeger, 200, body); len(res.Findings) > 0 {
+			t.Errorf("an envelope without errors should not match jaeger, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a bare data array is not flagged as jaeger", func(t *testing.T) {
+		if res := runObservabilityModule(t, jaeger, 200, `{"data":["x"]}`); len(res.Findings) > 0 {
+			t.Errorf("a bare data array should not match jaeger, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a zipkin config is flagged with its environment", func(t *testing.T) {
+		body := `{"environment":"prod","queryLimit":10,"defaultLookback":900000,"searchEnabled":true,` +
+			`"dependency":{"enabled":true,"lowErrorRate":0.5,"highErrorRate":0.75}}`
+		res := runObservabilityModule(t, zipkin, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a zipkin finding")
+		}
+		if v := observExtract(res, "zipkin_environment"); v != "prod" {
+			t.Errorf("zipkin_environment=%q, want prod", v)
+		}
+	})
+
+	t.Run("a config with searchEnabled alone is not flagged as zipkin", func(t *testing.T) {
+		if res := runObservabilityModule(t, zipkin, 200, `{"searchEnabled":true,"foo":1}`); len(res.Findings) > 0 {
+			t.Errorf("a partial config should not match zipkin, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{loki, jaeger, zipkin} {
+			if res := runObservabilityModule(t, file, 200, "ok"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{loki, jaeger, zipkin} {
+			if res := runObservabilityModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/recon/jaeger-query-exposure.yaml
+++ b/modules/recon/jaeger-query-exposure.yaml
@@ -1,0 +1,43 @@
+# Jaeger Query Service Exposure Detection Module
+
+id: jaeger-query-exposure
+info:
+  name: Jaeger Query Service Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed Jaeger query service that leaks the internal service topology and trace data over its unauthenticated api
+  tags: [jaeger, tracing, distributed-tracing, observability, topology, exposure, unauth, api, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/api/services"
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - '"data"\s*:\s*\['
+
+    - type: word
+      part: body
+      words:
+        - "\"total\""
+        - "\"limit\""
+        - "\"offset\""
+        - "\"errors\""
+      condition: and
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: jaeger_service
+      part: body
+      regex:
+        - '"data"\s*:\s*\[\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/loki-api-exposure.yaml
+++ b/modules/recon/loki-api-exposure.yaml
@@ -1,0 +1,39 @@
+# Grafana Loki Log API Exposure Detection Module
+
+id: loki-api-exposure
+info:
+  name: Grafana Loki Log API Exposure
+  author: sif
+  severity: high
+  description: Detects a Grafana Loki deployment with auth_enabled disabled that serves log labels and content to anyone over its query api
+  tags: [loki, grafana, logs, log-aggregation, observability, exposure, unauth, api, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/loki/api/v1/labels"
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - '"status"\s*:\s*"success"'
+
+    - type: word
+      part: body
+      words:
+        - "\"data\""
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: loki_label
+      part: body
+      regex:
+        - '"data"\s*:\s*\[\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/zipkin-exposure.yaml
+++ b/modules/recon/zipkin-exposure.yaml
@@ -1,0 +1,37 @@
+# Zipkin Tracing Server Exposure Detection Module
+
+id: zipkin-exposure
+info:
+  name: Zipkin Tracing Server Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed Zipkin server that leaks the internal service topology and trace data over its unauthenticated api
+  tags: [zipkin, tracing, distributed-tracing, observability, topology, exposure, unauth, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/zipkin/config.json"
+
+  matchers:
+    - type: word
+      part: body
+      words:
+        - "\"queryLimit\""
+        - "\"defaultLookback\""
+        - "\"searchEnabled\""
+      condition: and
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: zipkin_environment
+      part: body
+      regex:
+        - '"environment"\s*:\s*"([^"]*)"'
+      group: 1


### PR DESCRIPTION
`modules/recon/loki-api-exposure.yaml` flags a grafana loki deployment running with `auth_enabled` off, keyed on the `"status":"success"` envelope paired with the `data` label array on `/loki/api/v1/labels`, then extracts the first label; loki wants the `X-Scope-OrgID` tenant header when auth is on (401 without it), so a tenant-less 200 means logs are readable. `modules/recon/jaeger-query-exposure.yaml` flags an exposed jaeger query service leaking its internal service topology over `/api/services`, keyed on the `data` array paired with the `total`/`limit`/`offset`/`errors` envelope fields, then extracts the first service. `modules/recon/zipkin-exposure.yaml` flags a reachable zipkin tracing server over `/zipkin/config.json`, keyed on the `queryLimit`, `defaultLookback` and `searchEnabled` lens-ui config fields, then extracts the environment.

build/vet/lint clean, `go test ./internal/modules/` green (the three modules end to end via `ExecuteHTTPModule`, real-hit and near-miss cases).
