### PR TITLE
feat(modules): add caddy and envoy admin exposure modules

### DIFF
--- a/internal/modules/server_admin_exposure_test.go
+++ b/internal/modules/server_admin_exposure_test.go
@@ -1,0 +1,101 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+func runServerAdminModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func serverAdminExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestServerAdminExposureModules(t *testing.T) {
+	const caddy = "../../modules/recon/caddy-admin-exposure.yaml"
+	const envoy = "../../modules/recon/envoy-admin-exposure.yaml"
+
+	t.Run("a caddy config dump is flagged with a handler", func(t *testing.T) {
+		body := `{"apps":{"http":{"servers":{"srv0":{"listen":[":443"],"routes":[{"match":[{"host":` +
+			`["example.com"]}],"handle":[{"handler":"reverse_proxy","upstreams":[{"dial":"localhost:8080"}]}]}]}}},` +
+			`"tls":{"automation":{"policies":[{"issuers":[{"module":"acme"}]}]}}},"admin":{"listen":"0.0.0.0:2019"}}`
+		res := runServerAdminModule(t, caddy, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a caddy finding")
+		}
+		if v := serverAdminExtract(res, "caddy_handler"); v != "reverse_proxy" {
+			t.Errorf("caddy_handler=%q, want reverse_proxy", v)
+		}
+	})
+
+	t.Run("an apps block without servers or handler is not flagged as caddy", func(t *testing.T) {
+		if res := runServerAdminModule(t, caddy, 200, `{"apps":{"tls":{"automation":{}}}}`); len(res.Findings) > 0 {
+			t.Errorf("an apps-only tls block should not match caddy, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an envoy server_info is flagged with its version", func(t *testing.T) {
+		body := `{"version":"1.28.0/abcd/Clean/RELEASE/BoringSSL","state":"LIVE","uptime_current_epoch":"3600s",` +
+			`"uptime_all_epochs":"3600s","hot_restart_version":"11.104","command_line_options":{"base_id":"0",` +
+			`"concurrency":4,"config_path":"/etc/envoy/envoy.yaml"},"node":{"id":"node-1","cluster":"prod"}}`
+		res := runServerAdminModule(t, envoy, 200, body)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected an envoy finding")
+		}
+		if v := serverAdminExtract(res, "envoy_version"); v != "1.28.0/abcd/Clean/RELEASE/BoringSSL" {
+			t.Errorf("envoy_version=%q, want the build string", v)
+		}
+	})
+
+	t.Run("a bare version+state body is not flagged as envoy", func(t *testing.T) {
+		if res := runServerAdminModule(t, envoy, 200, `{"version":"1.0","state":"LIVE"}`); len(res.Findings) > 0 {
+			t.Errorf("a bare version+state should not match envoy, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a plain 200 body is not a leak", func(t *testing.T) {
+		for _, file := range []string{caddy, envoy} {
+			if res := runServerAdminModule(t, file, 200, "ok"); len(res.Findings) > 0 {
+				t.Errorf("%s: a plain 200 body should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+
+	t.Run("a 404 is not a leak", func(t *testing.T) {
+		for _, file := range []string{caddy, envoy} {
+			if res := runServerAdminModule(t, file, 404, "not found"); len(res.Findings) > 0 {
+				t.Errorf("%s: a 404 should not match, got %d findings", file, len(res.Findings))
+			}
+		}
+	})
+}

--- a/modules/recon/caddy-admin-exposure.yaml
+++ b/modules/recon/caddy-admin-exposure.yaml
@@ -1,0 +1,41 @@
+# Caddy Admin API Exposure Detection Module
+
+id: caddy-admin-exposure
+info:
+  name: Caddy Admin API Exposure
+  author: sif
+  severity: high
+  description: Detects a Caddy admin api bound to a routable address that leaks the running config and accepts config-replacing loads
+  tags: [caddy, reverse-proxy, web-server, admin, api, controlplane, exposure, unauth, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/config/"
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - '"apps"\s*:\s*\{'
+
+    - type: word
+      part: body
+      words:
+        - "\"servers\""
+        - "\"handler\""
+      condition: and
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: caddy_handler
+      part: body
+      regex:
+        - '"handler"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/envoy-admin-exposure.yaml
+++ b/modules/recon/envoy-admin-exposure.yaml
@@ -1,0 +1,41 @@
+# Envoy Proxy Admin Interface Exposure Detection Module
+
+id: envoy-admin-exposure
+info:
+  name: Envoy Admin Interface Exposure
+  author: sif
+  severity: high
+  description: Detects an exposed Envoy admin interface that leaks build and config details and exposes runtime shutdown and modification
+  tags: [envoy, proxy, service-mesh, admin, controlplane, exposure, unauth, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/server_info"
+
+  matchers:
+    - type: word
+      part: body
+      words:
+        - "\"hot_restart_version\""
+        - "\"command_line_options\""
+      condition: and
+
+    - type: regex
+      part: body
+      regex:
+        - '"state"\s*:\s*"(LIVE|PRE_INITIALIZING|INITIALIZING|DRAINING)"'
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: envoy_version
+      part: body
+      regex:
+        - '"version"\s*:\s*"([^"]+)"'
+      group: 1


### PR DESCRIPTION
`modules/recon/caddy-admin-exposure.yaml` flags a caddy admin api bound to a routable address over `/config/`, keyed on the `apps` block paired with the `servers` and `handler` fields, then extracts the first handler; the admin api is unauthenticated and meant for loopback, so a 200 exposes the running config and a `POST /load` that replaces it. `modules/recon/envoy-admin-exposure.yaml` flags an exposed envoy proxy admin interface over `/server_info`, keyed on the `hot_restart_version` and `command_line_options` fields paired with the server `state`, then extracts the version; the same interface offers `/config_dump` secrets and `/quitquitquit`.

build/vet/lint clean, `go test ./internal/modules/` green (the two modules end to end via `ExecuteHTTPModule`, real-hit and near-miss cases).
