### PR TITLE
feat(modules): add zookeeper and hadoop namenode exposure modules

### DIFF
--- a/internal/modules/hadoop_zookeeper_exposure_test.go
+++ b/internal/modules/hadoop_zookeeper_exposure_test.go
@@ -1,0 +1,128 @@
+package modules_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+const zkMonitorBody = `{"command":"monitor","error":null,"version":"3.9.2-a8d7f3e",` +
+	`"server_state":"leader","avg_latency":0,"max_latency":12,"min_latency":0,` +
+	`"packets_received":1532,"packets_sent":1531,"num_alive_connections":3,` +
+	`"outstanding_requests":0,"znode_count":127,"watch_count":4,"ephemerals_count":2,` +
+	`"approximate_data_size":45219,"open_file_descriptor_count":67,"max_file_descriptor_count":1048576}`
+
+const nameNodeInfoBody = `{"beans":[{"name":"Hadoop:service=NameNode,name=NameNodeInfo",` +
+	`"modelerType":"org.apache.hadoop.hdfs.server.namenode.FSNamesystem",` +
+	`"SoftwareVersion":"3.3.6","Version":"3.3.6, rUNKNOWN","Total":2147483648,"Free":1073741824,` +
+	`"Safemode":"","ClusterId":"CID-abc123","BlockPoolId":"BP-998-10.0.0.1-170",` +
+	`"LiveNodes":"{\"dn1.hdfs.internal:9866\":{\"infoAddr\":\"10.0.0.2:9864\"}}",` +
+	`"DeadNodes":"{}","DecomNodes":"{}","TotalBlocks":1024,"TotalFiles":512}]}`
+
+func runHadoopZKModule(t *testing.T, file string, status int, body string) *modules.Result {
+	t.Helper()
+	def, err := modules.ParseYAMLModule(file)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	res, err := modules.ExecuteHTTPModule(context.Background(), srv.URL, def, modules.Options{
+		Timeout: 5 * time.Second,
+		Threads: 2,
+	})
+	if err != nil {
+		t.Fatalf("execute %s: %v", file, err)
+	}
+	return res
+}
+
+func hadoopZKExtract(res *modules.Result, key string) string {
+	for _, f := range res.Findings {
+		if v := f.Extracted[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestHadoopZooKeeperExposureModules(t *testing.T) {
+	const zk = "../../modules/recon/zookeeper-admin-exposure.yaml"
+	const namenode = "../../modules/recon/hadoop-namenode-exposure.yaml"
+
+	t.Run("an open zookeeper monitor is flagged with the version", func(t *testing.T) {
+		res := runHadoopZKModule(t, zk, 200, zkMonitorBody)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a zookeeper finding")
+		}
+		if v := hadoopZKExtract(res, "zookeeper_version"); v != "3.9.2-a8d7f3e" {
+			t.Errorf("zookeeper_version=%q, want 3.9.2-a8d7f3e", v)
+		}
+	})
+
+	t.Run("a different adminserver command is not flagged", func(t *testing.T) {
+		body := `{"command":"configuration","error":null,"version":"3.9.2","clientPort":2181}`
+		if res := runHadoopZKModule(t, zk, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a non-monitor command should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a firewalled or absent adminserver is not flagged", func(t *testing.T) {
+		if res := runHadoopZKModule(t, zk, 404, "not found"); len(res.Findings) > 0 {
+			t.Errorf("a 404 should not match zookeeper, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a namenode jmx body does not match the zookeeper module", func(t *testing.T) {
+		if res := runHadoopZKModule(t, zk, 200, nameNodeInfoBody); len(res.Findings) > 0 {
+			t.Errorf("a namenode body should not match zookeeper, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("an open namenode jmx is flagged with the hdfs version", func(t *testing.T) {
+		res := runHadoopZKModule(t, namenode, 200, nameNodeInfoBody)
+		if len(res.Findings) == 0 {
+			t.Fatal("expected a namenode finding")
+		}
+		if v := hadoopZKExtract(res, "hdfs_version"); v != "3.3.6" {
+			t.Errorf("hdfs_version=%q, want 3.3.6", v)
+		}
+	})
+
+	t.Run("a different hadoop jmx bean is not flagged", func(t *testing.T) {
+		body := `{"beans":[{"name":"Hadoop:service=DataNode,name=DataNodeInfo",` +
+			`"SoftwareVersion":"3.3.6","LiveNodes":"","DeadNodes":""}]}`
+		if res := runHadoopZKModule(t, namenode, 200, body); len(res.Findings) > 0 {
+			t.Errorf("a non-NameNodeInfo bean should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a kerberos-secured namenode is not flagged", func(t *testing.T) {
+		if res := runHadoopZKModule(t, namenode, 401, "Authentication required"); len(res.Findings) > 0 {
+			t.Errorf("a 401 namenode should not match, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("a zookeeper monitor body does not match the namenode module", func(t *testing.T) {
+		if res := runHadoopZKModule(t, namenode, 200, zkMonitorBody); len(res.Findings) > 0 {
+			t.Errorf("a zookeeper body should not match namenode, got %d findings", len(res.Findings))
+		}
+	})
+
+	t.Run("plain 200 bodies are not leaks", func(t *testing.T) {
+		if res := runHadoopZKModule(t, zk, 200, "ok"); len(res.Findings) > 0 {
+			t.Errorf("a plain 200 should not match zookeeper, got %d findings", len(res.Findings))
+		}
+		if res := runHadoopZKModule(t, namenode, 200, "ok"); len(res.Findings) > 0 {
+			t.Errorf("a plain 200 should not match namenode, got %d findings", len(res.Findings))
+		}
+	})
+}

--- a/modules/recon/hadoop-namenode-exposure.yaml
+++ b/modules/recon/hadoop-namenode-exposure.yaml
@@ -1,0 +1,41 @@
+# Hadoop HDFS NameNode Exposure Detection Module
+
+id: hadoop-namenode-exposure
+info:
+  name: Hadoop HDFS NameNode Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed Hadoop HDFS NameNode jmx interface that leaks the version, capacity and every datanode's internal hostname
+  tags: [hadoop, hdfs, namenode, apache, big-data, jmx, information-disclosure, exposure, unauth, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/jmx?qry=Hadoop:service=NameNode,name=NameNodeInfo"
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - '"name"\s*:\s*"Hadoop:service=NameNode,name=NameNodeInfo"'
+
+    - type: word
+      part: body
+      words:
+        - "\"LiveNodes\""
+        - "\"DeadNodes\""
+      condition: and
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: hdfs_version
+      part: body
+      regex:
+        - '"SoftwareVersion"\s*:\s*"([^"]+)"'
+      group: 1

--- a/modules/recon/zookeeper-admin-exposure.yaml
+++ b/modules/recon/zookeeper-admin-exposure.yaml
@@ -1,0 +1,39 @@
+# ZooKeeper AdminServer Exposure Detection Module
+
+id: zookeeper-admin-exposure
+info:
+  name: ZooKeeper AdminServer Exposure
+  author: sif
+  severity: medium
+  description: Detects an exposed Apache ZooKeeper AdminServer whose monitor command leaks the version, ensemble role and znode and watch counts
+  tags: [zookeeper, apache, coordination, adminserver, information-disclosure, exposure, unauth, recon]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/commands/monitor"
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - '"command"\s*:\s*"monitor"'
+
+    - type: word
+      part: body
+      words:
+        - "\"server_state\""
+
+    - type: status
+      status:
+        - 200
+
+  extractors:
+    - type: regex
+      name: zookeeper_version
+      part: body
+      regex:
+        - '"version"\s*:\s*"([^"]+)"'
+      group: 1


### PR DESCRIPTION
`modules/recon/zookeeper-admin-exposure.yaml` flags an exposed apache zookeeper adminserver over `/commands/monitor`, keyed on the `"command":"monitor"` response envelope paired with the `server_state` field, then extracts the version; the adminserver (default port 8080 since 3.5) has no auth on its read commands, leaking the ensemble role, connection counts and data size. `modules/recon/hadoop-namenode-exposure.yaml` flags an exposed hadoop hdfs namenode jmx interface over `/jmx?qry=Hadoop:service=NameNode,name=NameNodeInfo`, keyed on that bean name paired with the `LiveNodes` and `DeadNodes` attributes, then extracts the software version; the namenode jmx is anonymous unless kerberos spnego is configured, and `LiveNodes` carries every datanode's internal hostname.

build/vet/lint clean, `go test ./internal/modules/` green (the two modules end to end via `ExecuteHTTPModule`, real-hit and near-miss cases).
