### PR TITLE
ci(claude-review): skip fork & dependabot PRs where auth is unavailable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # OIDC tokens and repo secrets are withheld from pull_request runs that
+    # originate from forks or dependabot, so the action cannot authenticate
+    # there and the check fails for every external PR. Skip those cases (the
+    # job simply does not run) instead of failing. Same-repo branch PRs still
+    # get reviewed. To review fork PRs too, switch the trigger to
+    # pull_request_target (has a security trade-off) rather than loosening this.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The `claude-review` check fails on every external contributor PR with "Could not fetch an OIDC token". Root cause: `pull_request` runs from forks and dependabot are denied OIDC tokens and repo secrets by GitHub, so `anthropics/claude-code-action` can't authenticate (run shows `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` empty).

Fix: guard the job to same-repo, non-dependabot PRs so it **skips** those cases instead of red-X'ing them. Same-repo branch PRs still get reviewed. Reviewing fork PRs would require `pull_request_target` (security trade-off), intentionally left out.