### PR TITLE
feat(modules): add active web-vuln probe modules

### DIFF
--- a/modules/http/command-injection.yaml
+++ b/modules/http/command-injection.yaml
@@ -1,5 +1,3 @@
-# OS Command Injection Detection Module
-
 id: command-injection
 info:
   name: OS Command Injection

--- a/modules/http/command-injection.yaml
+++ b/modules/http/command-injection.yaml
@@ -1,0 +1,53 @@
+# OS Command Injection Detection Module
+
+id: command-injection
+info:
+  name: OS Command Injection
+  author: sif
+  severity: critical
+  description: Detects OS command injection by confirming the output of an injected id command in the response
+  tags: [rce, injection, command-injection, owasp-top10]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/?cmd={{payload}}"
+    - "{{BaseURL}}/?exec={{payload}}"
+    - "{{BaseURL}}/?ping={{payload}}"
+    - "{{BaseURL}}/?host={{payload}}"
+    - "{{BaseURL}}/?ip={{payload}}"
+    - "{{BaseURL}}/?query={{payload}}"
+    - "{{BaseURL}}/?q={{payload}}"
+
+  # each payload chains the id command onto the parameter value; a match
+  # requires id's actual output, so a benign echo of the payload cannot
+  # trigger the detector.
+  payloads:
+    - ";id"
+    - "|id"
+    - "||id"
+    - "&&id"
+    - "`id`"
+    - "$(id)"
+    - "%0aid"
+    - ";id;"
+    - "127.0.0.1;id"
+
+  threads: 10
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - "\\buid=[0-9]+\\([a-z0-9_.-]+\\)\\s+gid=[0-9]+\\("
+      condition: or
+
+  extractors:
+    - type: regex
+      name: id_output
+      part: body
+      regex:
+        - "(\\buid=[0-9]+\\([a-z0-9_.-]+\\)\\s+gid=[0-9]+\\([a-z0-9_.-]+\\))"
+      group: 1

--- a/modules/http/ldap-injection-error.yaml
+++ b/modules/http/ldap-injection-error.yaml
@@ -1,5 +1,3 @@
-# LDAP Injection Error-Based Detection Module
-
 id: ldap-injection-error
 info:
   name: LDAP Injection (Error-Based)

--- a/modules/http/ldap-injection-error.yaml
+++ b/modules/http/ldap-injection-error.yaml
@@ -1,0 +1,54 @@
+# LDAP Injection Error-Based Detection Module
+
+id: ldap-injection-error
+info:
+  name: LDAP Injection (Error-Based)
+  author: sif
+  severity: high
+  description: Detects LDAP injection via LDAP filter and directory error messages
+  tags: [ldap, injection, directory, owasp-top10]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/?user={{payload}}"
+    - "{{BaseURL}}/?username={{payload}}"
+    - "{{BaseURL}}/?uid={{payload}}"
+    - "{{BaseURL}}/?search={{payload}}"
+    - "{{BaseURL}}/?q={{payload}}"
+    - "{{BaseURL}}/?name={{payload}}"
+
+  payloads:
+    - "*"
+    - ")(cn=*"
+    - "*)(uid=*"
+    - "admin)(&"
+    - "*)(|(uid=*"
+    - "*()|"
+
+  threads: 10
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - "javax\\.naming\\.NameNotFoundException"
+        - "javax\\.naming\\.directory"
+        - "com\\.sun\\.jndi\\.ldap"
+        - "LDAPException"
+        - "Invalid DN syntax"
+        - "Bad search filter"
+        - "ldap_search"
+        - "supplied argument is not a valid ldap"
+        - "Protocol error occurred"
+      condition: or
+
+  extractors:
+    - type: regex
+      name: ldap_error
+      part: body
+      regex:
+        - "(LDAPException|javax\\.naming\\.[A-Za-z.]+|com\\.sun\\.jndi\\.ldap|Invalid DN syntax)"
+      group: 1

--- a/modules/http/nosql-injection-error.yaml
+++ b/modules/http/nosql-injection-error.yaml
@@ -1,5 +1,3 @@
-# NoSQL Injection Error-Based Detection Module
-
 id: nosql-injection-error
 info:
   name: NoSQL Injection (Error-Based)

--- a/modules/http/nosql-injection-error.yaml
+++ b/modules/http/nosql-injection-error.yaml
@@ -1,0 +1,53 @@
+# NoSQL Injection Error-Based Detection Module
+
+id: nosql-injection-error
+info:
+  name: NoSQL Injection (Error-Based)
+  author: sif
+  severity: high
+  description: Detects NoSQL injection via MongoDB driver error messages
+  tags: [nosql, injection, mongodb, database, owasp-top10]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/?id={{payload}}"
+    - "{{BaseURL}}/?user={{payload}}"
+    - "{{BaseURL}}/?username={{payload}}"
+    - "{{BaseURL}}/?search={{payload}}"
+    - "{{BaseURL}}/?q={{payload}}"
+    - "{{BaseURL}}/?filter={{payload}}"
+
+  payloads:
+    - "'"
+    - "\""
+    - "\\"
+    - "';return true;var x='"
+    - "{\"$gt\":\"\"}"
+    - "[$ne]=1"
+
+  threads: 10
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - "MongoError"
+        - "MongoServerError"
+        - "MongoParseError"
+        - "E11000 duplicate key"
+        - "CastError"
+        - "BSONError"
+        - "BSONTypeError"
+        - "MongoNetworkError"
+      condition: or
+
+  extractors:
+    - type: regex
+      name: nosql_error
+      part: body
+      regex:
+        - "(Mongo[A-Za-z]*Error|E11000 duplicate key|CastError|BSON[A-Za-z]*Error)"
+      group: 1

--- a/modules/http/ssti-reflected.yaml
+++ b/modules/http/ssti-reflected.yaml
@@ -1,5 +1,3 @@
-# Server-Side Template Injection Detection Module
-
 id: ssti-reflected
 info:
   name: Server-Side Template Injection

--- a/modules/http/ssti-reflected.yaml
+++ b/modules/http/ssti-reflected.yaml
@@ -1,0 +1,51 @@
+# Server-Side Template Injection Detection Module
+
+id: ssti-reflected
+info:
+  name: Server-Side Template Injection
+  author: sif
+  severity: high
+  description: Detects server-side template injection by confirming the engine evaluated an injected arithmetic expression
+  tags: [ssti, injection, template, rce, owasp-top10]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/?q={{payload}}"
+    - "{{BaseURL}}/?search={{payload}}"
+    - "{{BaseURL}}/?name={{payload}}"
+    - "{{BaseURL}}/?input={{payload}}"
+    - "{{BaseURL}}/?id={{payload}}"
+    - "{{BaseURL}}/?page={{payload}}"
+    - "{{BaseURL}}/?message={{payload}}"
+
+  # each payload evaluates to a distinctive product whose digits appear
+  # nowhere in the payload text, so a match proves the template engine
+  # computed the expression rather than reflecting the input verbatim.
+  payloads:
+    - "{{1337*1337}}"
+    - "${1337*1337}"
+    - "#{1337*1337}"
+    - "{1337*1337}"
+    - "<%= 1337*1337 %>"
+    - "${{1337*1337}}"
+    - "%7B%7B1337*1337%7D%7D"
+    - "%24%7B1337*1337%7D"
+
+  threads: 10
+
+  matchers:
+    - type: word
+      part: body
+      words:
+        - "1787569"
+
+  extractors:
+    - type: regex
+      name: evaluated
+      part: body
+      regex:
+        - "(1787569)"
+      group: 1

--- a/modules/http/xpath-injection-error.yaml
+++ b/modules/http/xpath-injection-error.yaml
@@ -1,5 +1,3 @@
-# XPath Injection Error-Based Detection Module
-
 id: xpath-injection-error
 info:
   name: XPath Injection (Error-Based)

--- a/modules/http/xpath-injection-error.yaml
+++ b/modules/http/xpath-injection-error.yaml
@@ -1,0 +1,55 @@
+# XPath Injection Error-Based Detection Module
+
+id: xpath-injection-error
+info:
+  name: XPath Injection (Error-Based)
+  author: sif
+  severity: high
+  description: Detects XPath injection via XPath parser error messages
+  tags: [xpath, injection, xml, owasp-top10]
+
+type: http
+
+http:
+  method: GET
+  paths:
+    - "{{BaseURL}}/?id={{payload}}"
+    - "{{BaseURL}}/?user={{payload}}"
+    - "{{BaseURL}}/?name={{payload}}"
+    - "{{BaseURL}}/?search={{payload}}"
+    - "{{BaseURL}}/?q={{payload}}"
+    - "{{BaseURL}}/?query={{payload}}"
+
+  payloads:
+    - "'"
+    - "\""
+    - "']"
+    - "')"
+    - "1'or'1'='1"
+    - "count(//*)"
+
+  threads: 10
+
+  matchers:
+    - type: regex
+      part: body
+      regex:
+        - "XPathException"
+        - "org\\.apache\\.xpath"
+        - "javax\\.xml\\.xpath"
+        - "MS\\.Internal\\.Xml"
+        - "System\\.Xml\\.XPath"
+        - "SimpleXMLElement::xpath"
+        - "xmlXPathEval"
+        - "Warning.*?xpath"
+        - "supplied argument is not a valid XPath"
+        - "Expression must evaluate to a node-set"
+      condition: or
+
+  extractors:
+    - type: regex
+      name: xpath_error
+      part: body
+      regex:
+        - "(XPathException|SimpleXMLElement::xpath|xmlXPathEval|org\\.apache\\.xpath)"
+      group: 1


### PR DESCRIPTION
Five active-probe modules for `modules/http`: `ssti-reflected` (arithmetic-eval proof, matches 1787569 = eval of 1337*1337), `command-injection` (matches id output shape `uid=N(...) gid=N(...)`, not the payload echo), and error-based `xpath`, `nosql`, `ldap`.

Each keys on a transformed response the payload cannot produce by reflection, so a benign echo of the input cannot trigger a finding. Verified with an eval-server vs echo-server pair: eval fires, echo stays silent for every module.