### PR TITLE
feat(scan): add cdn provider detection pool

### DIFF
--- a/internal/scan/builtin/cdn_module.go
+++ b/internal/scan/builtin/cdn_module.go
@@ -1,0 +1,91 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/vmfunc/sif/internal/httpx"
+	"github.com/vmfunc/sif/internal/modules"
+	"github.com/vmfunc/sif/internal/scan/frameworks"
+)
+
+// cdnMaxBodySize caps the response body read, mirroring frameworks.maxBodySize.
+const cdnMaxBodySize = 5 * 1024 * 1024
+
+type CDNModule struct{}
+
+func (m *CDNModule) Info() modules.Info {
+	return modules.Info{
+		ID:          "cdn-detection",
+		Name:        "CDN/Hosting Provider Detection",
+		Author:      "sif",
+		Severity:    "info",
+		Description: "Fingerprints the cdn/edge/hosting provider fronting a target from response headers",
+		Tags:        []string{"recon", "cdn", "hosting", "fingerprint"},
+	}
+}
+
+func (m *CDNModule) Type() modules.ModuleType {
+	return modules.TypeHTTP
+}
+
+// Execute fetches the target and runs the CDN detector pool over the response,
+// independent of framework detection (see cdnRegistry in
+// internal/scan/frameworks/cdn.go).
+func (m *CDNModule) Execute(ctx context.Context, target string, opts modules.Options) (*modules.Result, error) {
+	client := opts.Client
+	if client == nil {
+		client = httpx.Client(opts.Timeout)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, cdnMaxBodySize))
+	if err != nil {
+		return nil, err
+	}
+
+	result := &modules.Result{
+		ModuleID: m.Info().ID,
+		Target:   target,
+		Findings: []modules.Finding{},
+	}
+
+	cdn := frameworks.DetectCDN(string(body), resp.Header)
+	if cdn == nil {
+		return result, nil
+	}
+
+	result.Findings = append(result.Findings, modules.Finding{
+		URL:      target,
+		Severity: "info",
+		Evidence: fmt.Sprintf("Fronted by %s (confidence: %.2f)", cdn.Name, cdn.Confidence),
+		Extracted: map[string]string{
+			"cdn":        cdn.Name,
+			"confidence": fmt.Sprintf("%.2f", cdn.Confidence),
+		},
+	})
+
+	return result, nil
+}

--- a/internal/scan/builtin/cdn_module.go
+++ b/internal/scan/builtin/cdn_module.go
@@ -14,16 +14,12 @@ package builtin
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/vmfunc/sif/internal/httpx"
 	"github.com/vmfunc/sif/internal/modules"
 	"github.com/vmfunc/sif/internal/scan/frameworks"
 )
-
-// cdnMaxBodySize caps the response body read, mirroring frameworks.maxBodySize.
-const cdnMaxBodySize = 5 * 1024 * 1024
 
 type CDNModule struct{}
 
@@ -55,16 +51,13 @@ func (m *CDNModule) Execute(ctx context.Context, target string, opts modules.Opt
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:bodyclose // drained and closed via httpx.DrainClose
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, cdnMaxBodySize))
-	if err != nil {
-		return nil, err
-	}
+	// every CDN signature is HeaderOnly, so the body is never inspected; drain
+	// and close it (no per-target body allocation) and detect on headers alone.
+	defer httpx.DrainClose(resp)
 
 	result := &modules.Result{
 		ModuleID: m.Info().ID,
@@ -72,7 +65,7 @@ func (m *CDNModule) Execute(ctx context.Context, target string, opts modules.Opt
 		Findings: []modules.Finding{},
 	}
 
-	cdn := frameworks.DetectCDN(string(body), resp.Header)
+	cdn := frameworks.DetectCDN("", resp.Header)
 	if cdn == nil {
 		return result, nil
 	}

--- a/internal/scan/builtin/cdn_module_test.go
+++ b/internal/scan/builtin/cdn_module_test.go
@@ -1,0 +1,83 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+/*
+
+   BSD 3-Clause License
+   (c) 2022-2026 vmfunc, xyzeva & contributors
+
+*/
+
+package builtin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vmfunc/sif/internal/modules"
+	// import the detectors package for its init() so the CDN detector pool
+	// is registered when the module runs.
+	_ "github.com/vmfunc/sif/internal/scan/frameworks/detectors"
+)
+
+func TestCDNModule_DetectsCloudflare(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("CF-RAY", "7d1f4a2b3c4d5e6f-LAX")
+		w.Header().Set("Server", "cloudflare")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`<!DOCTYPE html><html><body>Hello</body></html>`))
+	}))
+	defer server.Close()
+
+	m := &CDNModule{}
+	result, err := m.Execute(context.Background(), server.URL, modules.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a result, got nil")
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(result.Findings))
+	}
+	if got := result.Findings[0].Extracted["cdn"]; got != "Cloudflare" {
+		t.Errorf("expected cdn 'Cloudflare', got %q", got)
+	}
+	if sev := result.Findings[0].Severity; sev != "info" {
+		t.Errorf("expected severity 'info' (a cdn is a pure fingerprint), got %q", sev)
+	}
+}
+
+func TestCDNModule_NoCDN(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// generic origin headers, no edge-injected vendor marker.
+		w.Header().Set("Server", "nginx")
+		w.Header().Set("X-Powered-By", "PHP/8.2.0")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`<!DOCTYPE html><html><body>Plain origin</body></html>`))
+	}))
+	defer server.Close()
+
+	m := &CDNModule{}
+	result, err := m.Execute(context.Background(), server.URL, modules.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a result, got nil")
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("expected no findings on a plain origin, got %d (%+v)", len(result.Findings), result.Findings)
+	}
+}

--- a/internal/scan/builtin/register.go
+++ b/internal/scan/builtin/register.go
@@ -19,6 +19,7 @@ import "github.com/vmfunc/sif/internal/modules"
 func Register() {
 	modules.Register(&ShodanModule{})
 	modules.Register(&FrameworksModule{})
+	modules.Register(&CDNModule{})
 	modules.Register(&NucleiModule{})
 	modules.Register(&WhoisModule{})
 	modules.Register(&SecurityTrailsModule{})

--- a/internal/scan/frameworks/cdn.go
+++ b/internal/scan/frameworks/cdn.go
@@ -1,0 +1,94 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+/*
+
+   BSD 3-Clause License
+   (c) 2022-2026 vmfunc, xyzeva & contributors
+
+*/
+
+package frameworks
+
+import (
+	"net/http"
+	"sync"
+)
+
+// cdnRegistry holds CDN/hosting/edge detectors, kept separate from registry
+// (see detector.go) because a CDN/edge is orthogonal to an application
+// framework: a target can be both Cloudflare-fronted and Next.js. DetectFramework
+// takes a single global-argmax winner, so a CDN detector in registry would
+// outrank the real framework (a bare cf-ray header scores ~0.999 via
+// sigmoidConfidence) and report "Cloudflare" instead of "Next.js". A separate
+// registry reduced by its own DetectCDN lets both answers coexist.
+var (
+	cdnRegistryMu sync.RWMutex
+	cdnRegistry   = make(map[string]Detector)
+)
+
+// RegisterCDN adds a CDN/hosting detector. should be called from init().
+func RegisterCDN(d Detector) {
+	cdnRegistryMu.Lock()
+	defer cdnRegistryMu.Unlock()
+	cdnRegistry[d.Name()] = d
+}
+
+// GetCDNDetectors returns all registered CDN/hosting detectors.
+func GetCDNDetectors() map[string]Detector {
+	cdnRegistryMu.RLock()
+	defer cdnRegistryMu.RUnlock()
+
+	result := make(map[string]Detector, len(cdnRegistry))
+	for k, v := range cdnRegistry {
+		result[k] = v
+	}
+	return result
+}
+
+// cdnDetectionThreshold mirrors detectionThreshold in detect.go: below this,
+// report no CDN rather than a weak guess.
+const cdnDetectionThreshold = 0.5
+
+// CDNResult is CDN/hosting-provider detection output. It is a separate type from
+// FrameworkResult because the two come from independent pools and either can be
+// absent while the other is present.
+type CDNResult struct {
+	Name       string  `json:"name"`
+	Confidence float32 `json:"confidence"`
+}
+
+// ResultType implements the ScanResult interface.
+func (r *CDNResult) ResultType() string { return "cdn" }
+
+// DetectCDN runs every registered CDN/hosting detector against an already-fetched
+// response and returns the best match, or nil below cdnDetectionThreshold. Unlike
+// DetectFramework it takes body/headers directly, so a caller with a response in
+// hand can run both detections off one request.
+func DetectCDN(body string, headers http.Header) *CDNResult {
+	detectors := GetCDNDetectors()
+	if len(detectors) == 0 {
+		return nil
+	}
+
+	var best CDNResult
+	for _, d := range detectors {
+		confidence, _ := d.Detect(body, headers)
+		if confidence > best.Confidence || (confidence == best.Confidence && confidence > 0 && d.Name() < best.Name) {
+			best = CDNResult{Name: d.Name(), Confidence: confidence}
+		}
+	}
+
+	if best.Confidence <= cdnDetectionThreshold {
+		return nil
+	}
+	return &best
+}

--- a/internal/scan/frameworks/cdn_test.go
+++ b/internal/scan/frameworks/cdn_test.go
@@ -1,0 +1,116 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+/*
+
+   BSD 3-Clause License
+   (c) 2022-2026 vmfunc, xyzeva & contributors
+
+*/
+
+package frameworks_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vmfunc/sif/internal/scan/frameworks"
+	// import detectors to register both the framework and CDN detector pools
+	// via their respective init()s.
+	_ "github.com/vmfunc/sif/internal/scan/frameworks/detectors"
+)
+
+// TestDetectFramework_CloudflareFrontedNextJS locks the anti-suppression fix: a
+// Cloudflare-fronted Next.js site must report Next.js from DetectFramework and
+// Cloudflare from the independent DetectCDN, not one crowding out the other. A
+// Cloudflare detector in the shared registry would instead win the global argmax
+// on cf-ray alone (see TestCDNSignatureWouldOutrankFramework).
+func TestDetectFramework_CloudflareFrontedNextJS(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("CF-RAY", "7d1f4a2b3c4d5e6f-LAX")
+		w.Header().Set("Server", "cloudflare")
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			<!DOCTYPE html>
+			<html>
+			<head><title>Test</title></head>
+			<body>
+				<script id="__NEXT_DATA__" type="application/json">{"props":{}}</script>
+				<script src="/_next/static/chunks/main.js"></script>
+			</body>
+			</html>
+		`))
+	}))
+	defer server.Close()
+
+	fwResult, err := frameworks.DetectFramework(server.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("DetectFramework: unexpected error: %v", err)
+	}
+	if fwResult == nil {
+		t.Fatal("DetectFramework: expected a result, got nil")
+	}
+	if fwResult.Name != "Next.js" {
+		t.Fatalf("DetectFramework: expected 'Next.js' despite the Cloudflare headers, got %q (confidence %.3f): a CDN detector is suppressing framework detection",
+			fwResult.Name, fwResult.Confidence)
+	}
+
+	// fetch the same response and run the CDN pool over it directly, the way a
+	// caller that already holds a response runs both detections off one request.
+	resp, err := http.Get(server.URL) //nolint:gosec,bodyclose // test server, closed below
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	cdnResult := frameworks.DetectCDN(string(body), resp.Header)
+	if cdnResult == nil {
+		t.Fatal("DetectCDN: expected a result, got nil")
+	}
+	if cdnResult.Name != "Cloudflare" {
+		t.Errorf("DetectCDN: expected 'Cloudflare', got %q", cdnResult.Name)
+	}
+}
+
+// TestCDNSignatureWouldOutrankFramework shows why CDN detectors stay out of
+// DetectFramework's registry: a single-signature CDN detector (a bare cf-ray
+// header, weight 1.0, no dilution) beats even a strong Next.js match under the
+// shared sigmoidConfidence curve.
+func TestCDNSignatureWouldOutrankFramework(t *testing.T) {
+	cloudflare := frameworks.NewBaseDetector("Cloudflare", []frameworks.Signature{
+		{Pattern: "cf-ray", Weight: 1.0, HeaderOnly: true},
+	})
+	nextjs := frameworks.NewBaseDetector("Next.js", []frameworks.Signature{
+		{Pattern: "__NEXT_DATA__", Weight: 0.5},
+		{Pattern: "_next/static", Weight: 0.4},
+		{Pattern: "__next", Weight: 0.3},
+		{Pattern: "x-nextjs", Weight: 0.3, HeaderOnly: true},
+	})
+
+	headers := http.Header{}
+	headers.Set("CF-RAY", "7d1f4a2b3c4d5e6f-LAX")
+	body := `<script id="__NEXT_DATA__">{}</script><script src="/_next/static/x.js"></script>`
+
+	cfScore := cloudflare.MatchSignatures(body, headers)
+	nextScore := nextjs.MatchSignatures(body, headers)
+
+	if cfScore <= nextScore {
+		t.Fatalf("expected the single-signature CDN score (%.3f) to exceed the diluted framework score (%.3f), the setup that motivated RegisterCDN as a separate pool", cfScore, nextScore)
+	}
+}

--- a/internal/scan/frameworks/cdn_test.go
+++ b/internal/scan/frameworks/cdn_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,4 +114,39 @@ func TestCDNSignatureWouldOutrankFramework(t *testing.T) {
 	if cfScore <= nextScore {
 		t.Fatalf("expected the single-signature CDN score (%.3f) to exceed the diluted framework score (%.3f), the setup that motivated RegisterCDN as a separate pool", cfScore, nextScore)
 	}
+}
+
+// TestDetectCDNTieBreakIsDeterministic locks the ordering rule: GetCDNDetectors
+// returns a map, so two detectors scoring identically would otherwise report a
+// different winner run to run.
+func TestDetectCDNTieBreakIsDeterministic(t *testing.T) {
+	const marker = "sif-tie-break-marker"
+	frameworks.RegisterCDN(tiedDetector{name: "zz-sif-test-cdn", marker: marker})
+	frameworks.RegisterCDN(tiedDetector{name: "aa-sif-test-cdn", marker: marker})
+
+	for i := 0; i < 50; i++ {
+		got := frameworks.DetectCDN("<html>"+marker+"</html>", http.Header{})
+		if got == nil {
+			t.Fatal("expected a tied detector to be reported")
+		}
+		if got.Name != "aa-sif-test-cdn" {
+			t.Fatalf("tie resolved to %q, want the lexicographically first name", got.Name)
+		}
+	}
+}
+
+// tiedDetector scores a fixed 0.9 on its marker, so two of them tie exactly.
+type tiedDetector struct {
+	name   string
+	marker string
+}
+
+func (d tiedDetector) Name() string                       { return d.name }
+func (d tiedDetector) Signatures() []frameworks.Signature { return nil }
+
+func (d tiedDetector) Detect(body string, _ http.Header) (float32, string) {
+	if strings.Contains(body, d.marker) {
+		return 0.9, ""
+	}
+	return 0, ""
 }

--- a/internal/scan/frameworks/detector.go
+++ b/internal/scan/frameworks/detector.go
@@ -33,6 +33,11 @@ type Signature struct {
 	// Header, when set, scopes a HeaderOnly match to the named header's value
 	// (canonical form, e.g. "X-Powered-By"). Empty matches across all headers.
 	Header string
+	// Presence, with Header set, matches on the header existing at all rather
+	// than on its value. an edge marker like CF-Ray carries an opaque id, so
+	// there is no value to match; what identifies the provider is that the
+	// header was stamped. Pattern is unused.
+	Presence bool
 }
 
 // Detector is the interface for framework detection plugins.
@@ -111,9 +116,12 @@ func (b BaseDetector) MatchSignatures(body string, headers http.Header) float32 
 
 		if sig.HeaderOnly {
 			var matched bool
-			if sig.Header != "" {
+			switch {
+			case sig.Presence:
+				matched = len(headers.Values(sig.Header)) > 0
+			case sig.Header != "":
 				matched = headerValueContains(headers, sig.Header, sig.Pattern)
-			} else {
+			default:
 				matched = containsHeader(headers, sig.Pattern)
 			}
 			if matched {

--- a/internal/scan/frameworks/detectors/cdn.go
+++ b/internal/scan/frameworks/detectors/cdn.go
@@ -1,0 +1,148 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+/*
+
+   BSD 3-Clause License
+   (c) 2022-2026 vmfunc, xyzeva & contributors
+
+*/
+
+package detectors
+
+import (
+	"net/http"
+
+	fw "github.com/vmfunc/sif/internal/scan/frameworks"
+)
+
+func init() {
+	// registered against fw.RegisterCDN, not fw.Register: these compete in
+	// their own DetectCDN argmax, never against application frameworks. see
+	// the comment on cdnRegistry in cdn.go for why.
+	fw.RegisterCDN(&cloudflareDetector{})
+	fw.RegisterCDN(&fastlyDetector{})
+	fw.RegisterCDN(&akamaiDetector{})
+	fw.RegisterCDN(&cloudfrontDetector{})
+	fw.RegisterCDN(&vercelDetector{})
+	fw.RegisterCDN(&netlifyDetector{})
+}
+
+// all CDN signatures are HeaderOnly and scoped to the specific edge-injected
+// header the provider controls, never a bare brand substring: a page that
+// merely mentions "cloudflare" in its body (a badge, a blog post, a status
+// widget) must not fire, only the response the edge itself stamped.
+
+// cloudflareDetector detects the Cloudflare CDN/edge.
+type cloudflareDetector struct{}
+
+func (d *cloudflareDetector) Name() string { return "Cloudflare" }
+
+func (d *cloudflareDetector) Signatures() []fw.Signature {
+	return []fw.Signature{
+		// header name cf-ray is injected by every Cloudflare-proxied response.
+		{Pattern: "cf-ray", Weight: 0.6, HeaderOnly: true},
+		{Pattern: "cloudflare", Weight: 0.4, HeaderOnly: true, Header: "Server"},
+	}
+}
+
+func (d *cloudflareDetector) Detect(body string, headers http.Header) (float32, string) {
+	base := fw.NewBaseDetector(d.Name(), d.Signatures())
+	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
+}
+
+// fastlyDetector detects the Fastly CDN.
+type fastlyDetector struct{}
+
+func (d *fastlyDetector) Name() string { return "Fastly" }
+
+func (d *fastlyDetector) Signatures() []fw.Signature {
+	return []fw.Signature{
+		// x-fastly-request-id is only emitted by fastly's own edge; a plain
+		// varnish deployment (fastly is varnish-based) never sends it, so this
+		// stays clear of the generic "Via: 1.1 varnish" false positive.
+		{Pattern: "x-fastly-request-id", Weight: 0.6, HeaderOnly: true},
+		{Pattern: "fastly", Weight: 0.4, HeaderOnly: true, Header: "Via"},
+	}
+}
+
+func (d *fastlyDetector) Detect(body string, headers http.Header) (float32, string) {
+	base := fw.NewBaseDetector(d.Name(), d.Signatures())
+	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
+}
+
+// akamaiDetector detects the Akamai CDN/edge.
+type akamaiDetector struct{}
+
+func (d *akamaiDetector) Name() string { return "Akamai" }
+
+func (d *akamaiDetector) Signatures() []fw.Signature {
+	return []fw.Signature{
+		{Pattern: "akamai-grn", Weight: 0.5, HeaderOnly: true},
+		{Pattern: "x-akamai", Weight: 0.5, HeaderOnly: true},
+	}
+}
+
+func (d *akamaiDetector) Detect(body string, headers http.Header) (float32, string) {
+	base := fw.NewBaseDetector(d.Name(), d.Signatures())
+	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
+}
+
+// cloudfrontDetector detects AWS CloudFront.
+type cloudfrontDetector struct{}
+
+func (d *cloudfrontDetector) Name() string { return "Amazon CloudFront" }
+
+func (d *cloudfrontDetector) Signatures() []fw.Signature {
+	return []fw.Signature{
+		{Pattern: "x-amz-cf-id", Weight: 0.5, HeaderOnly: true},
+		{Pattern: "cloudfront", Weight: 0.5, HeaderOnly: true, Header: "Via"},
+	}
+}
+
+func (d *cloudfrontDetector) Detect(body string, headers http.Header) (float32, string) {
+	base := fw.NewBaseDetector(d.Name(), d.Signatures())
+	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
+}
+
+// vercelDetector detects Vercel's edge network.
+type vercelDetector struct{}
+
+func (d *vercelDetector) Name() string { return "Vercel" }
+
+func (d *vercelDetector) Signatures() []fw.Signature {
+	return []fw.Signature{
+		{Pattern: "x-vercel-id", Weight: 0.5, HeaderOnly: true},
+		{Pattern: "vercel", Weight: 0.5, HeaderOnly: true, Header: "Server"},
+	}
+}
+
+func (d *vercelDetector) Detect(body string, headers http.Header) (float32, string) {
+	base := fw.NewBaseDetector(d.Name(), d.Signatures())
+	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
+}
+
+// netlifyDetector detects Netlify's edge network.
+type netlifyDetector struct{}
+
+func (d *netlifyDetector) Name() string { return "Netlify" }
+
+func (d *netlifyDetector) Signatures() []fw.Signature {
+	return []fw.Signature{
+		{Pattern: "x-nf-request-id", Weight: 0.5, HeaderOnly: true},
+		{Pattern: "netlify", Weight: 0.5, HeaderOnly: true, Header: "Server"},
+	}
+}
+
+func (d *netlifyDetector) Detect(body string, headers http.Header) (float32, string) {
+	base := fw.NewBaseDetector(d.Name(), d.Signatures())
+	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
+}

--- a/internal/scan/frameworks/detectors/cdn.go
+++ b/internal/scan/frameworks/detectors/cdn.go
@@ -41,7 +41,6 @@ func init() {
 // merely mentions "cloudflare" in its body (a badge, a blog post, a status
 // widget) must not fire, only the response the edge itself stamped.
 
-// cloudflareDetector detects the Cloudflare CDN/edge.
 type cloudflareDetector struct{}
 
 func (d *cloudflareDetector) Name() string { return "Cloudflare" }
@@ -59,7 +58,6 @@ func (d *cloudflareDetector) Detect(body string, headers http.Header) (float32, 
 	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
 }
 
-// fastlyDetector detects the Fastly CDN.
 type fastlyDetector struct{}
 
 func (d *fastlyDetector) Name() string { return "Fastly" }
@@ -79,7 +77,6 @@ func (d *fastlyDetector) Detect(body string, headers http.Header) (float32, stri
 	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
 }
 
-// akamaiDetector detects the Akamai CDN/edge.
 type akamaiDetector struct{}
 
 func (d *akamaiDetector) Name() string { return "Akamai" }
@@ -96,7 +93,6 @@ func (d *akamaiDetector) Detect(body string, headers http.Header) (float32, stri
 	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
 }
 
-// cloudfrontDetector detects AWS CloudFront.
 type cloudfrontDetector struct{}
 
 func (d *cloudfrontDetector) Name() string { return "Amazon CloudFront" }
@@ -113,7 +109,6 @@ func (d *cloudfrontDetector) Detect(body string, headers http.Header) (float32, 
 	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
 }
 
-// vercelDetector detects Vercel's edge network.
 type vercelDetector struct{}
 
 func (d *vercelDetector) Name() string { return "Vercel" }
@@ -130,7 +125,6 @@ func (d *vercelDetector) Detect(body string, headers http.Header) (float32, stri
 	return sigmoidConfidence(base.MatchSignatures(body, headers)), ""
 }
 
-// netlifyDetector detects Netlify's edge network.
 type netlifyDetector struct{}
 
 func (d *netlifyDetector) Name() string { return "Netlify" }

--- a/internal/scan/frameworks/detectors/cdn.go
+++ b/internal/scan/frameworks/detectors/cdn.go
@@ -36,10 +36,17 @@ func init() {
 	fw.RegisterCDN(&netlifyDetector{})
 }
 
-// all CDN signatures are HeaderOnly and scoped to the specific edge-injected
-// header the provider controls, never a bare brand substring: a page that
-// merely mentions "cloudflare" in its body (a badge, a blog post, a status
-// widget) must not fire, only the response the edge itself stamped.
+// all CDN signatures are HeaderOnly and scoped to a specific header the
+// provider controls, never a bare substring matched across every header.
+//
+// vendor markers match on Presence, because the value is an opaque request id
+// and what identifies the provider is that the header was stamped at all. that
+// also keeps them off header values: an origin advertising
+// "Access-Control-Expose-Headers: CF-Ray" is naming a header, not sitting
+// behind cloudflare.
+//
+// brand words are scoped to the header that carries them (Server, Via), so a
+// CSP or Link header referencing a cdn-hosted asset cannot fire them.
 
 type cloudflareDetector struct{}
 
@@ -48,7 +55,7 @@ func (d *cloudflareDetector) Name() string { return "Cloudflare" }
 func (d *cloudflareDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
 		// header name cf-ray is injected by every Cloudflare-proxied response.
-		{Pattern: "cf-ray", Weight: 0.6, HeaderOnly: true},
+		{Header: "CF-Ray", Presence: true, Weight: 0.6, HeaderOnly: true},
 		{Pattern: "cloudflare", Weight: 0.4, HeaderOnly: true, Header: "Server"},
 	}
 }
@@ -67,7 +74,7 @@ func (d *fastlyDetector) Signatures() []fw.Signature {
 		// x-fastly-request-id is only emitted by fastly's own edge; a plain
 		// varnish deployment (fastly is varnish-based) never sends it, so this
 		// stays clear of the generic "Via: 1.1 varnish" false positive.
-		{Pattern: "x-fastly-request-id", Weight: 0.6, HeaderOnly: true},
+		{Header: "X-Fastly-Request-ID", Presence: true, Weight: 0.6, HeaderOnly: true},
 		{Pattern: "fastly", Weight: 0.4, HeaderOnly: true, Header: "Via"},
 	}
 }
@@ -83,8 +90,8 @@ func (d *akamaiDetector) Name() string { return "Akamai" }
 
 func (d *akamaiDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "akamai-grn", Weight: 0.5, HeaderOnly: true},
-		{Pattern: "x-akamai", Weight: 0.5, HeaderOnly: true},
+		{Header: "Akamai-GRN", Presence: true, Weight: 0.5, HeaderOnly: true},
+		{Header: "X-Akamai-Transformed", Presence: true, Weight: 0.5, HeaderOnly: true},
 	}
 }
 
@@ -99,7 +106,7 @@ func (d *cloudfrontDetector) Name() string { return "Amazon CloudFront" }
 
 func (d *cloudfrontDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "x-amz-cf-id", Weight: 0.5, HeaderOnly: true},
+		{Header: "X-Amz-Cf-Id", Presence: true, Weight: 0.5, HeaderOnly: true},
 		{Pattern: "cloudfront", Weight: 0.5, HeaderOnly: true, Header: "Via"},
 	}
 }
@@ -115,7 +122,7 @@ func (d *vercelDetector) Name() string { return "Vercel" }
 
 func (d *vercelDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "x-vercel-id", Weight: 0.5, HeaderOnly: true},
+		{Header: "X-Vercel-Id", Presence: true, Weight: 0.5, HeaderOnly: true},
 		{Pattern: "vercel", Weight: 0.5, HeaderOnly: true, Header: "Server"},
 	}
 }
@@ -131,7 +138,7 @@ func (d *netlifyDetector) Name() string { return "Netlify" }
 
 func (d *netlifyDetector) Signatures() []fw.Signature {
 	return []fw.Signature{
-		{Pattern: "x-nf-request-id", Weight: 0.5, HeaderOnly: true},
+		{Header: "X-Nf-Request-Id", Presence: true, Weight: 0.5, HeaderOnly: true},
 		{Pattern: "netlify", Weight: 0.5, HeaderOnly: true, Header: "Server"},
 	}
 }

--- a/internal/scan/frameworks/detectors/cdn_test.go
+++ b/internal/scan/frameworks/detectors/cdn_test.go
@@ -108,3 +108,54 @@ func TestCDNDetectors_NotInFrameworkRegistry(t *testing.T) {
 		}
 	}
 }
+
+// an origin that merely references cdn-hosted assets in a header is the common
+// case, not an edge deployment: a CSP naming cdnjs.cloudflare.com, a Link
+// preconnect to a cloudfront bucket, a vercel.app frame-ancestor. none of those
+// are stamped by an edge, so the brand-word signatures (which are scoped to the
+// Server/Via the provider controls) must not fire on them.
+func TestCDNIgnoresBrandWordsInUnrelatedHeaders(t *testing.T) {
+	origin := http.Header{}
+	origin.Set("Server", "nginx/1.24.0")
+	origin.Set("Content-Security-Policy",
+		"default-src 'self'; script-src https://cdnjs.cloudflare.com; "+
+			"img-src https://assets.cloudfront.net; frame-ancestors https://preview.vercel.app; "+
+			"connect-src https://api.netlify.com https://cdn.fastly.net")
+	origin.Set("Link", "<https://d111111abcdef8.cloudfront.net/app.css>; rel=preload; as=style")
+	origin.Set("X-Powered-By", "Express")
+
+	if got := fw.DetectCDN("<html>powered by cloudflare</html>", origin); got != nil {
+		t.Errorf("plain nginx origin referencing cdn assets reported as %q (confidence %.3f)", got.Name, got.Confidence)
+	}
+}
+
+// the flip side: a response the edge actually stamped still resolves.
+func TestCDNDetectsRealEdgeHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{name: "cloudflare", headers: map[string]string{"CF-RAY": "8a1b2c3d4e5f6789-LAX", "Server": "cloudflare"}, want: "Cloudflare"},
+		{name: "fastly", headers: map[string]string{"X-Fastly-Request-ID": "abc123", "Via": "1.1 varnish (Varnish/6.0)"}, want: "Fastly"},
+		{name: "cloudfront", headers: map[string]string{"X-Amz-Cf-Id": "abc==", "Via": "1.1 abc.cloudfront.net (CloudFront)"}, want: "Amazon CloudFront"},
+		{name: "vercel", headers: map[string]string{"X-Vercel-Id": "sfo1::abc", "Server": "Vercel"}, want: "Vercel"},
+		{name: "netlify", headers: map[string]string{"X-NF-Request-ID": "abc", "Server": "Netlify"}, want: "Netlify"},
+		{name: "akamai", headers: map[string]string{"X-Akamai-Transformed": "9 0 0", "Akamai-GRN": "0.1a2b"}, want: "Akamai"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			for k, v := range tt.headers {
+				h.Set(k, v)
+			}
+			got := fw.DetectCDN("<html></html>", h)
+			if got == nil {
+				t.Fatalf("no cdn detected for real %s edge headers", tt.name)
+			}
+			if got.Name != tt.want {
+				t.Errorf("DetectCDN = %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scan/frameworks/detectors/cdn_test.go
+++ b/internal/scan/frameworks/detectors/cdn_test.go
@@ -159,3 +159,19 @@ func TestCDNDetectsRealEdgeHeaders(t *testing.T) {
 		})
 	}
 }
+
+// an origin advertising which of its headers CORS clients may read is naming
+// header names in a header VALUE, not sitting behind that edge. matching a
+// vendor marker across every header value turns the most common CORS config
+// into a cdn detection, so those markers match on header presence instead.
+func TestCDNIgnoresVendorHeaderNamesInValues(t *testing.T) {
+	origin := http.Header{}
+	origin.Set("Server", "nginx/1.24.0")
+	origin.Set("Access-Control-Expose-Headers",
+		"CF-Ray, X-Amz-Cf-Id, X-Vercel-Id, X-Fastly-Request-Id, X-NF-Request-ID, Akamai-GRN")
+	origin.Set("Vary", "Accept-Encoding, X-Akamai-Transformed")
+
+	if got := fw.DetectCDN("<html></html>", origin); got != nil {
+		t.Errorf("plain nginx origin reported as %q (confidence %.4f) from vendor header names quoted in a value", got.Name, got.Confidence)
+	}
+}

--- a/internal/scan/frameworks/detectors/cdn_test.go
+++ b/internal/scan/frameworks/detectors/cdn_test.go
@@ -1,0 +1,110 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+/*
+
+   BSD 3-Clause License
+   (c) 2022-2026 vmfunc, xyzeva & contributors
+
+*/
+
+package detectors
+
+import (
+	"net/http"
+	"testing"
+
+	fw "github.com/vmfunc/sif/internal/scan/frameworks"
+)
+
+// cdnHeaders builds a header set from name/value pairs for readability in
+// the table below (unlike accHeader in accuracy_test.go, most CDN cases need
+// more than one header set at once).
+func cdnHeaders(pairs ...string) http.Header {
+	h := http.Header{}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		h.Set(pairs[i], pairs[i+1])
+	}
+	return h
+}
+
+func TestCDNDetectors_TruePositives(t *testing.T) {
+	cases := []struct {
+		name string
+		det  fw.Detector
+		h    http.Header
+	}{
+		{"Cloudflare ray + server", &cloudflareDetector{}, cdnHeaders("CF-RAY", "7d1f4a2b3c4d5e6f-LAX", "Server", "cloudflare")},
+		{"Fastly request id", &fastlyDetector{}, cdnHeaders("X-Fastly-Request-ID", "3a2b1c", "Via", "1.1 varnish")},
+		{"Akamai grn", &akamaiDetector{}, cdnHeaders("Akamai-GRN", "0.abcd1234.1234567.abcdef", "X-Cache", "TCP_MISS from a23-1-2-3.akamai.net")},
+		{"CloudFront amz id + via", &cloudfrontDetector{}, cdnHeaders("X-Amz-Cf-Id", "abc123", "Via", "1.1 abcdef.cloudfront.net (CloudFront)")},
+		{"Vercel id + server", &vercelDetector{}, cdnHeaders("X-Vercel-Id", "sfo1::abcde", "Server", "Vercel")},
+		{"Netlify request id + server", &netlifyDetector{}, cdnHeaders("X-Nf-Request-Id", "01abc", "Server", "Netlify")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if conf, _ := c.det.Detect("", c.h); conf <= 0.5 {
+				t.Errorf("missed: confidence = %.3f, want > 0.5", conf)
+			}
+		})
+	}
+}
+
+func TestCDNDetectors_FalsePositives(t *testing.T) {
+	cases := []struct {
+		name string
+		det  fw.Detector
+		h    http.Header
+	}{
+		// generic reverse proxy: a Via header with no vendor token at all.
+		{"Cloudflare vs generic via-only proxy", &cloudflareDetector{}, cdnHeaders("Via", "1.1 proxy.internal")},
+		// self-hosted varnish, no fastly-only header present.
+		{"Fastly vs bare varnish", &fastlyDetector{}, cdnHeaders("Via", "1.1 varnish (Varnish/6.0)", "X-Cache", "HIT")},
+		// generic x-cache/x-served-by pair a lot of CDN-agnostic caches emit.
+		{"Akamai vs generic cache headers", &akamaiDetector{}, cdnHeaders("X-Cache", "HIT", "X-Served-By", "cache-lax1")},
+		{"CloudFront vs generic via proxy", &cloudfrontDetector{}, cdnHeaders("Via", "1.1 mycompany-proxy")},
+		{"Vercel vs generic node server", &vercelDetector{}, cdnHeaders("Server", "nginx", "X-Powered-By", "Express")},
+		{"Netlify vs generic static host", &netlifyDetector{}, cdnHeaders("Server", "nginx")},
+		// prose/body mention: badge markup naming the provider must never
+		// count, only headers the edge itself stamps.
+		{"Cloudflare body-only badge", &cloudflareDetector{}, http.Header{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := ""
+			if c.name == "Cloudflare body-only badge" {
+				body = `<img src="/cloudflare-badge.png" alt="Protected by Cloudflare">`
+			}
+			if conf, _ := c.det.Detect(body, c.h); conf > 0.5 {
+				t.Errorf("false positive: confidence = %.3f, want <= 0.5", conf)
+			}
+		})
+	}
+}
+
+func TestCDNDetectors_Registered(t *testing.T) {
+	for _, name := range []string{"Cloudflare", "Fastly", "Akamai", "Amazon CloudFront", "Vercel", "Netlify"} {
+		if _, ok := fw.GetCDNDetectors()[name]; !ok {
+			t.Errorf("%s should be registered via RegisterCDN", name)
+		}
+	}
+}
+
+func TestCDNDetectors_NotInFrameworkRegistry(t *testing.T) {
+	// the whole point of RegisterCDN is that these never compete in
+	// DetectFramework's single-winner argmax. prove none leaked into the
+	// shared registry via a stray fw.Register call.
+	for _, name := range []string{"Cloudflare", "Fastly", "Akamai", "Amazon CloudFront", "Vercel", "Netlify"} {
+		if _, ok := fw.GetDetector(name); ok {
+			t.Errorf("%s must not be in the shared framework registry (breaks argmax isolation)", name)
+		}
+	}
+}


### PR DESCRIPTION
detect cdn providers via a dedicated detection pool separate from the
framework single-argmax reducer, so a cdn match cannot suppress a
framework match. new cdn-detection module fetches once, runs
frameworks.DetectCDN, and emits one info finding for the highest-confidence
provider (DetectCDN is itself single-argmax).


the brand-word signatures are scoped with `Header: Server` / `Header: Via`, which MatchSignatures routes through headerValueContains rather than the all-headers containsHeader. a test pins the case that protects: an nginx origin whose CSP and Link headers reference cdnjs.cloudflare.com, a cloudfront bucket, a vercel.app frame-ancestor and a netlify api, with no edge header anywhere, stays unreported.
