### PR TITLE
fix(scan): strip url whitespace before open-redirect host check

### DIFF
--- a/internal/scan/redirect.go
+++ b/internal/scan/redirect.go
@@ -274,6 +274,13 @@ func pointsAtSentinel(location string) bool {
 		return false
 	}
 
+	// a location like " //host" or "htt\tps://host" still navigates off-site
+	// in a browser even though it fails net/url's stricter parse.
+	location = stripURLWhitespace(location)
+	if location == "" {
+		return false
+	}
+
 	// browsers treat backslashes in the authority as forward slashes
 	normalized := strings.ReplaceAll(location, "\\", "/")
 
@@ -297,6 +304,14 @@ func pointsAtSentinel(location string) bool {
 	}
 
 	return false
+}
+
+// stripURLWhitespace mirrors the whatwg url parser's whitespace pass: trim
+// leading/trailing c0 control or space, then strip every tab, cr and lf
+// wherever they occur.
+func stripURLWhitespace(s string) string {
+	s = strings.TrimFunc(s, func(r rune) bool { return r <= ' ' })
+	return strings.NewReplacer("\t", "", "\r", "", "\n", "").Replace(s)
 }
 
 // stripPort drops a trailing :port so host comparisons ignore it.

--- a/internal/scan/redirect_test.go
+++ b/internal/scan/redirect_test.go
@@ -152,6 +152,15 @@ func TestPointsAtSentinel(t *testing.T) {
 		{"opaque scheme not off-site", "mailto:" + redirectSentinel, false},
 		{"sentinel only in path", "https://safe.example.com/" + redirectSentinel, false},
 		{"sentinel only in query", "https://safe.example.com/?to=" + redirectSentinel, false},
+		{"leading space before scheme-relative", "  //" + redirectSentinel, true},
+		{"leading tab before scheme-relative", "\t//" + redirectSentinel, true},
+		{"tab injected inside scheme", "htt\tps://" + redirectSentinel, true},
+		{"trailing newline", "//" + redirectSentinel + "\n", true},
+		{"cr injected inside scheme", "ht\rtps://" + redirectSentinel, true},
+		// stripping leading/trailing whitespace must not turn a same-site target off-site
+		{"leading space same-site path", "  /login", false},
+		// a mid-string space is not a tab/newline, so it stays and the host stays same-site
+		{"mid-string space keeps host same-site", "https://safe.example.com/a b/" + redirectSentinel, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
pointsAtSentinel parsed the reflected location without the whitespace
and control-byte removal a browser applies, so payloads like a
space-prefixed scheme-relative host or a tab embedded in the scheme
parsed to an empty host and a real off-site redirect was missed. strip
leading and trailing c0-or-space and all tab, cr and lf before parsing,
matching the navigation-time normalization, without removing mid-string
spaces so a same-site target is never reclassified as off-site.
