### PR TITLE
fix(report): map sarif level to finding severity

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -18,9 +18,13 @@ package report
 import "encoding/json"
 
 // Result is one module's output for one target. Data is whatever the scanner
-// returned, carried as raw json so report stays free of scan types.
+// returned, carried as raw json so report stays free of scan types. Severity is
+// the normalized rank ("critical".."info", or "" when the source carries none),
+// passed in as a plain string so report keeps its independence from the finding
+// package; the sarif writer maps it onto a sarif level.
 type Result struct {
-	Target string
-	Module string
-	Data   json.RawMessage
+	Target   string
+	Module   string
+	Severity string
+	Data     json.RawMessage
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -98,6 +98,45 @@ func TestSARIF_DedupesRulesAcrossTargets(t *testing.T) {
 	}
 }
 
+func TestSARIF_LevelFromSeverity(t *testing.T) {
+	// each severity string must map onto the right sarif level, and an absent
+	// severity falls back to the neutral "warning".
+	results := []Result{
+		{Target: "https://t", Module: "critical-mod", Severity: "critical", Data: json.RawMessage(`{}`)},
+		{Target: "https://t", Module: "high-mod", Severity: "high", Data: json.RawMessage(`{}`)},
+		{Target: "https://t", Module: "medium-mod", Severity: "medium", Data: json.RawMessage(`{}`)},
+		{Target: "https://t", Module: "low-mod", Severity: "low", Data: json.RawMessage(`{}`)},
+		{Target: "https://t", Module: "info-mod", Severity: "info", Data: json.RawMessage(`{}`)},
+		{Target: "https://t", Module: "none-mod", Severity: "", Data: json.RawMessage(`{}`)},
+	}
+	out, err := SARIF(results)
+	if err != nil {
+		t.Fatalf("SARIF: %v", err)
+	}
+	var doc sarifLog
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+
+	want := map[string]string{
+		"critical-mod": "error",
+		"high-mod":     "error",
+		"medium-mod":   "warning",
+		"low-mod":      "note",
+		"info-mod":     "note",
+		"none-mod":     "warning",
+	}
+	got := make(map[string]string)
+	for _, r := range doc.Runs[0].Results {
+		got[r.RuleID] = r.Level
+	}
+	for mod, level := range want {
+		if got[mod] != level {
+			t.Errorf("module %q: expected level %q, got %q", mod, level, got[mod])
+		}
+	}
+}
+
 func TestSARIF_Empty(t *testing.T) {
 	out, err := SARIF(nil)
 	if err != nil {

--- a/internal/report/sarif.go
+++ b/internal/report/sarif.go
@@ -73,9 +73,29 @@ type sarifArtifactLocation struct {
 	URI string `json:"uri"`
 }
 
-// sarifLevel is the default severity for findings; sif results don't carry a
-// uniform severity field, so "warning" is the neutral middle ground.
-const sarifLevel = "warning"
+// sarif levels this writer emits. the 2.1.0 spec also defines "none", but every
+// sif result is at least informational, so the floor here is "note".
+const (
+	sarifError   = "error"
+	sarifWarning = "warning"
+	sarifNote    = "note"
+)
+
+// sarifLevelFor maps a normalized finding severity onto a sarif level. an empty
+// or unrecognized severity falls back to "warning", the neutral middle ground
+// that preserves the old behavior for results that carry no severity.
+func sarifLevelFor(severity string) string {
+	switch severity {
+	case "critical", "high":
+		return sarifError
+	case "low", "info":
+		return sarifNote
+	case "medium":
+		return sarifWarning
+	default:
+		return sarifWarning
+	}
+}
 
 // SARIF serializes results to a minimal valid sarif 2.1.0 log. Each module
 // result becomes one sarif result tagged with its module id (the rule) and the
@@ -90,7 +110,7 @@ func SARIF(results []Result) ([]byte, error) {
 
 		sarifResults = append(sarifResults, sarifResult{
 			RuleID:  res.Module,
-			Level:   sarifLevel,
+			Level:   sarifLevelFor(res.Severity),
 			Message: sarifMessage{Text: messageFor(res)},
 			Locations: []sarifLocation{{
 				PhysicalLocation: sarifPhysicalLocation{

--- a/sif.go
+++ b/sif.go
@@ -852,9 +852,35 @@ func collectReportResults(target string, moduleResults []ModuleResult) []report.
 			log.Warnf("report: skipping %s result for %s: %v", mr.Id, target, err)
 			continue
 		}
-		out = append(out, report.Result{Target: target, Module: mr.Id, Data: data})
+		out = append(out, report.Result{
+			Target:   target,
+			Module:   mr.Id,
+			Severity: reportSeverity(target, mr),
+			Data:     data,
+		})
 	}
 	return out
+}
+
+// reportSeverity derives one severity string for a module result by flattening
+// it to per-item findings and taking the highest rank among them. a module
+// result can flatten to several severities; the worst is the meaningful one for
+// a single sarif result. an empty string means the source carried no severity.
+func reportSeverity(target string, mr ModuleResult) string {
+	findings := finding.Flatten(target, mr.Id, mr.Data)
+	if len(findings) == 0 {
+		return ""
+	}
+	worst := findings[0].Severity
+	for i := 1; i < len(findings); i++ {
+		if findings[i].Severity > worst {
+			worst = findings[i].Severity
+		}
+	}
+	if worst == finding.SeverityUnknown {
+		return ""
+	}
+	return worst.String()
 }
 
 // writeReports serializes the collected results to the requested export files.


### PR DESCRIPTION
sarif results were hardcoded to level "warning", so a critical finding
and an informational one landed identically in code-scanning ingests.
carry the normalized severity onto report.Result and map it: critical
and high to error, medium to warning, low and info to note. the severity
is derived by flattening each module result and taking the worst rank,
and an absent severity keeps the old "warning" default.
