### PR TITLE
feat(modules): embed built-in modules in the binary

### DIFF
--- a/embed_modules.go
+++ b/embed_modules.go
@@ -1,0 +1,40 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package sif
+
+import (
+	"embed"
+	"io/fs"
+
+	"github.com/charmbracelet/log"
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+// builtinModules embeds the module tree into the binary. this file lives at the
+// repo root because go:embed cannot reference a parent directory, and modules/
+// sits above internal/modules where the loader lives.
+//
+//go:embed modules
+var builtinModules embed.FS
+
+// register the embedded modules with the loader once, rooted at the modules
+// directory so paths match the on-disk layout. the loader only uses this as a
+// fallback when no filesystem modules/ dir is present.
+func init() {
+	sub, err := fs.Sub(builtinModules, "modules")
+	if err != nil {
+		log.Debugf("embedded modules unavailable: %v", err)
+		return
+	}
+	modules.SetBuiltinFS(sub)
+}

--- a/internal/modules/loader.go
+++ b/internal/modules/loader.go
@@ -14,6 +14,7 @@ package modules
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -22,10 +23,21 @@ import (
 	"github.com/vmfunc/sif/internal/output"
 )
 
+// builtinFS holds the modules embedded into the binary. it's set once, from the
+// repo-root package that can actually run the go:embed directive (go:embed can't
+// reach a parent directory, and modules/ sits above this package). it stays nil
+// in builds and tests that don't import that package, so the loader simply falls
+// back to the filesystem as before.
+var builtinFS fs.FS
+
+// SetBuiltinFS registers the embedded module filesystem. see builtinFS.
+func SetBuiltinFS(fsys fs.FS) { builtinFS = fsys }
+
 // Loader handles module discovery and loading.
 type Loader struct {
 	builtinDir string
 	userDir    string
+	embedded   fs.FS
 	loaded     int
 }
 
@@ -62,15 +74,26 @@ func NewLoader() (*Loader, error) {
 	return &Loader{
 		builtinDir: builtinDir,
 		userDir:    userDir,
+		embedded:   builtinFS,
 	}, nil
 }
 
 // LoadAll discovers and loads all modules from both built-in
 // and user directories.
 func (l *Loader) LoadAll() error {
-	// Load built-in modules first
+	// Load built-in modules first, preferring an on-disk modules/ dir (dev tree
+	// or a release that ships the folder alongside the binary).
+	before := l.loaded
 	if err := l.loadDir(l.builtinDir, false); err != nil {
 		log.Debugf("No built-in modules found: %v", err)
+	}
+
+	// nothing on disk: fall back to the modules embedded in the binary so a bare
+	// `go install`ed sif still ships its built-in modules.
+	if l.loaded == before && l.embedded != nil {
+		if err := l.loadFS(l.embedded); err != nil {
+			log.Debugf("No embedded modules loaded: %v", err)
+		}
 	}
 
 	// Load user modules (can override built-in)
@@ -114,6 +137,36 @@ func (l *Loader) loadDir(dir string, userDefined bool) error {
 			}
 		}
 
+		return nil
+	})
+}
+
+// loadFS loads yaml modules from an embedded filesystem. only yaml is embedded
+// (the .go script path is a filesystem-only dev affordance), so this walks for
+// yaml files and parses them from bytes.
+func (l *Loader) loadFS(fsys fs.FS) error {
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch filepath.Ext(path) {
+		case ".yaml", ".yml":
+			data, rerr := fs.ReadFile(fsys, path)
+			if rerr != nil {
+				log.Warnf("Failed to read embedded module %s: %v", path, rerr)
+				return nil
+			}
+			def, perr := ParseYAMLModuleBytes(data)
+			if perr != nil {
+				log.Warnf("Failed to load embedded module %s: %v", path, perr)
+				return nil
+			}
+			Register(newYAMLModuleWrapper(def, path))
+			l.loaded++
+		}
 		return nil
 	})
 }

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -88,7 +88,12 @@ func ParseYAMLModule(path string) (*YAMLModule, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read module file: %w", err)
 	}
+	return ParseYAMLModuleBytes(data)
+}
 
+// ParseYAMLModuleBytes parses and validates a module definition from raw bytes,
+// so the loader can read modules from an embedded fs.FS as well as from disk.
+func ParseYAMLModuleBytes(data []byte) (*YAMLModule, error) {
 	var ym YAMLModule
 	if err := yaml.Unmarshal(data, &ym); err != nil {
 		return nil, fmt.Errorf("parse yaml: %w", err)


### PR DESCRIPTION
modules loaded only from an exe-adjacent `modules/` dir or `~/.config/sif/modules`, so a bare `go install`ed binary shipped zero modules and silently found nothing to run.

embeds the `modules/` tree and falls back to it when no filesystem builtin dir is found. the on-disk builtin dir and the user-override dir still take precedence, so a dev tree and a release that ships the folder alongside the binary keep working unchanged.

the embed directive lives at the repo root because `go:embed` cannot reference a parent directory (`modules/` sits above `internal/modules` where the loader is); it registers the embedded fs with the loader through a small package hook to avoid an import cycle back into the root package.

verified: `--list-modules` from a directory with no `modules/` present lists all 192 built-ins (from the embed), and from the repo root it lists the same 192 off the filesystem with no double-loading.