### PR TITLE
feat(modules): add encoded word matcher option

### DIFF
--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -15,6 +15,8 @@ package modules
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -494,7 +496,14 @@ func checkMatcher(m *Matcher, resp *http.Response, body string) bool {
 		return false
 
 	case "word":
-		return checkWords(getPart(m.Part, resp, body), m.Words, m.Condition, m.CaseInsensitive)
+		words := m.Words
+		if m.Encoding != "" {
+			words = encodeMatcherWords(m.Words, m.Encoding)
+			if len(words) == 0 {
+				return false
+			}
+		}
+		return checkWords(getPart(m.Part, resp, body), words, m.Condition, m.CaseInsensitive)
 
 	case "regex":
 		return checkRegex(getPart(m.Part, resp, body), m.Regex, m.Condition)
@@ -593,6 +602,36 @@ func checkWords(content string, words []string, condition string, caseInsensitiv
 		}
 	}
 	return true
+}
+
+// encodeMatcherWord renders a plaintext word into the given encoding so a
+// marker that appears encoded in a response (a base64 blob, a hex dump) can
+// still be matched by its known plaintext form.
+func encodeMatcherWord(word, encoding string) (string, error) {
+	switch encoding {
+	case "":
+		return word, nil
+	case "hex":
+		return hex.EncodeToString([]byte(word)), nil
+	case "base64":
+		return base64.StdEncoding.EncodeToString([]byte(word)), nil
+	default:
+		return "", fmt.Errorf("unknown word encoding %q (use hex or base64)", encoding)
+	}
+}
+
+// encodeMatcherWords renders every word into the given encoding. an unknown
+// encoding drops all words, leaving nothing to match.
+func encodeMatcherWords(words []string, encoding string) []string {
+	out := make([]string, 0, len(words))
+	for _, w := range words {
+		e, err := encodeMatcherWord(w, encoding)
+		if err != nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 // checkRegex checks if any/all regex patterns match.

--- a/internal/modules/favicon.go
+++ b/internal/modules/favicon.go
@@ -67,12 +67,13 @@ func faviconEvidence(matchers []Matcher, body string) (string, bool) {
 	return fmt.Sprintf("favicon mmh3=%d", hash), true
 }
 
-// validateMatchers fails favicon matchers that would silently never fire (no
-// hash, or one out of 32-bit range) and malformed range matchers at load
-// rather than at match time.
+// validateMatchers fails at load, rather than at match time, matchers that would
+// silently never fire: favicon matchers with no hash or one out of 32-bit range,
+// malformed range matchers, and word matchers with an unknown encoding.
 func validateMatchers(matchers []Matcher) error {
 	for i := range matchers {
-		if matchers[i].Type == "favicon" {
+		switch matchers[i].Type {
+		case "favicon":
 			if len(matchers[i].Hash) == 0 {
 				return fmt.Errorf("favicon matcher requires at least one hash")
 			}
@@ -81,9 +82,7 @@ func validateMatchers(matchers []Matcher) error {
 					return fmt.Errorf("favicon hash %d out of range (use a signed int32 or unsigned uint32 value)", h)
 				}
 			}
-		}
-
-		if matchers[i].Type == "range" {
+		case "range":
 			if matchers[i].Min == nil && matchers[i].Max == nil {
 				return fmt.Errorf("range matcher requires min or max")
 			}
@@ -92,6 +91,14 @@ func validateMatchers(matchers []Matcher) error {
 			}
 			if matchers[i].Min != nil && matchers[i].Max != nil && *matchers[i].Min > *matchers[i].Max {
 				return fmt.Errorf("range matcher min %d greater than max %d", *matchers[i].Min, *matchers[i].Max)
+			}
+
+		case "word":
+			if matchers[i].Encoding == "" {
+				continue
+			}
+			if _, err := encodeMatcherWord("", matchers[i].Encoding); err != nil {
+				return fmt.Errorf("word matcher: %w", err)
 			}
 		}
 	}

--- a/internal/modules/matchers_test.go
+++ b/internal/modules/matchers_test.go
@@ -84,6 +84,72 @@ func TestCheckMatcherWord(t *testing.T) {
 	}
 }
 
+func TestCheckMatcherWordEncoding(t *testing.T) {
+	// base64("secretmarker") and hex("secretmarker") embedded in a larger body.
+	const b64Body = "prefix c2VjcmV0bWFya2Vy suffix"
+	const hexBody = "prefix 7365637265746d61726b6572 suffix"
+
+	tests := []struct {
+		name     string
+		words    []string
+		encoding string
+		body     string
+		expect   bool
+	}{
+		{name: "base64 word matches encoded body", words: []string{"secretmarker"}, encoding: "base64", body: b64Body, expect: true},
+		{name: "hex word matches encoded body", words: []string{"secretmarker"}, encoding: "hex", body: hexBody, expect: true},
+		// without encoding the plaintext word is not present in the encoded body.
+		{name: "no encoding does not match encoded body", words: []string{"secretmarker"}, encoding: "", body: b64Body, expect: false},
+		// a different marker encodes to something not present in the body.
+		{name: "base64 word absent from body misses", words: []string{"othermarker"}, encoding: "base64", body: b64Body, expect: false},
+		// unknown encoding drops every word, so nothing matches.
+		{name: "unknown encoding misses", words: []string{"secretmarker"}, encoding: "rot13", body: b64Body, expect: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Matcher{Type: "word", Part: "body", Words: tt.words, Encoding: tt.encoding}
+			resp := fakeResponse(t, 200, nil)
+			if got := checkMatcher(m, resp, tt.body); got != tt.expect {
+				t.Errorf("checkMatcher word encoding = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+
+	// an empty encoding must leave the default literal path byte-identical.
+	t.Run("empty encoding equals literal path", func(t *testing.T) {
+		const body = "welcome admin dashboard"
+		resp := fakeResponse(t, 200, nil)
+		lit := &Matcher{Type: "word", Part: "body", Words: []string{"admin"}}
+		enc := &Matcher{Type: "word", Part: "body", Words: []string{"admin"}, Encoding: ""}
+		if checkMatcher(lit, resp, body) != checkMatcher(enc, resp, body) {
+			t.Error("empty encoding diverged from literal matching")
+		}
+	})
+}
+
+func TestValidateMatchersEncoding(t *testing.T) {
+	tests := []struct {
+		name    string
+		matcher Matcher
+		wantErr bool
+	}{
+		{name: "no encoding is fine", matcher: Matcher{Type: "word", Words: []string{"anything"}}, wantErr: false},
+		{name: "base64 encoding accepted", matcher: Matcher{Type: "word", Words: []string{"secret"}, Encoding: "base64"}, wantErr: false},
+		{name: "hex encoding accepted", matcher: Matcher{Type: "word", Words: []string{"secret"}, Encoding: "hex"}, wantErr: false},
+		{name: "unknown encoding rejected", matcher: Matcher{Type: "word", Words: []string{"x"}, Encoding: "rot13"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMatchers([]Matcher{tt.matcher})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMatchers err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestCheckMatcherRegex(t *testing.T) {
 	const body = "version 1.2.3 build 99"
 

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -105,6 +105,8 @@ type Matcher struct {
 	Max *int `yaml:"max,omitempty"`
 	// CaseInsensitive folds word matching to lower-case when set (word matcher only).
 	CaseInsensitive bool `yaml:"case-insensitive,omitempty"`
+	// Encoding encodes each word before matching: hex or base64. word only.
+	Encoding string `yaml:"encoding,omitempty"`
 }
 
 // Extractor defines data extraction from responses.


### PR DESCRIPTION
word matchers gain an optional encoding of hex or base64. when set, each
configured plaintext word is rendered into that encoding before matching,
so a marker that appears encoded in a response (a base64 blob, a hex dump)
can be matched by its known plaintext form. an unset encoding keeps the
existing literal behaviour byte for byte. an unknown encoding value is
rejected at module load.
