### PR TITLE
refactor(cli): drop comments restating adjacent dns/subdomain code

### DIFF
--- a/sif.go
+++ b/sif.go
@@ -472,11 +472,10 @@ func (app *App) scanTarget(url, storeDir string, wantReport bool) (targetScan, e
 			log.Errorf("Error while running dns scan: %s", err)
 		} else {
 			moduleResults = append(moduleResults, ModuleResult{"dnslist", result})
-			dnsResults = result // Store the DNS results
+			dnsResults = result
 			scansRun = append(scansRun, "DNS Scan")
 		}
 
-		// Only run subdomain takeover check if DNS scan is enabled
 		if app.settings.SubdomainTakeover {
 			result, err := scan.SubdomainTakeover(url, dnsResults, app.settings.Timeout, app.settings.Threads, app.settings.LogDir)
 			if err != nil {


### PR DESCRIPTION
two comments in scanTarget restate the line they sit above: `dnsResults = result // Store the DNS results`, and a `// Only run subdomain takeover check if DNS scan is enabled` above the `if app.settings.SubdomainTakeover` it describes. drop both.

this PR previously carried the scanTarget/targetScan extraction as well. that landed on main in #367 with the same signature and the same `sif_scantarget_test.go`, so only the comment trim is left here.