### PR TITLE
fix(report): dedup header findings by key with deterministic sort

### DIFF
--- a/internal/finding/finding.go
+++ b/internal/finding/finding.go
@@ -20,6 +20,7 @@ package finding
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -482,16 +483,34 @@ func flattenProbe(target string, r *scan.ProbeResult) []Finding {
 
 func flattenHeaders(target string, rs []scan.HeaderResult) []Finding {
 	out := make([]Finding, 0, len(rs))
+	// a multi-valued header (Set-Cookie is the canonical case) emits one
+	// HeaderResult per value, and keying on the name alone collapses every
+	// value but the first onto one dedup Key. disambiguate by how many times
+	// the name has been seen rather than by the value: the value would
+	// destabilize every volatile single-valued header (Date, ETag, Age, CF-Ray)
+	// against the run-stable Key contract.
+	//
+	// the count is per name, not the slice index. headers.go ranges over
+	// resp.Header, so a name's position in the slice is randomized per run
+	// while the order of values within one name is preserved.
+	//
+	// the separator is ":", which rfc7230 excludes from a header field-name, so
+	// the suffix cannot collide with a real header. "#" would: it is a valid
+	// tchar, so a header literally named "Foo#1" would take the key of the
+	// second "Foo".
+	seen := make(map[string]int, len(rs))
 	for i := 0; i < len(rs); i++ {
 		h := rs[i]
-		// a multi-valued header (Set-Cookie is the canonical case) emits one
-		// HeaderResult per value; the value must ride in the identifier or
-		// every value but the first collapses onto one dedup Key.
+		identifier := h.Name
+		if n := seen[h.Name]; n > 0 {
+			identifier += ":" + strconv.Itoa(n)
+		}
+		seen[h.Name]++
 		out = append(out, Finding{
 			Target:   target,
 			Module:   "headers",
 			Severity: sevRecon,
-			Key:      key("headers", h.Name+":"+h.Value),
+			Key:      key("headers", identifier),
 			Title:    h.Name,
 			Raw:      h.Value,
 		})

--- a/internal/finding/finding.go
+++ b/internal/finding/finding.go
@@ -19,6 +19,7 @@ package finding
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
@@ -83,78 +84,79 @@ func key(module, identifier string) string {
 // keyed "module:unhandled" so a new scanner surfaces loudly instead of
 // vanishing - the guard test asserts this never happens for a known type.
 func Flatten(target, module string, result any) []Finding {
+	var out []Finding
 	switch r := result.(type) {
 	case *scan.ShodanResult:
-		return flattenShodan(target, r)
+		out = flattenShodan(target, r)
 	case *scan.SQLResult:
-		return flattenSQL(target, r)
+		out = flattenSQL(target, r)
 	case *scan.LFIResult:
-		return flattenLFI(target, r)
+		out = flattenLFI(target, r)
 	case *scan.JWTResult:
-		return flattenJWT(target, r)
+		out = flattenJWT(target, r)
 	case *scan.OpenAPIResult:
-		return flattenOpenAPI(target, r)
+		out = flattenOpenAPI(target, r)
 	case *scan.FaviconResult:
-		return flattenFavicon(target, r)
+		out = flattenFavicon(target, r)
 	case *scan.CMSResult:
-		return flattenCMS(target, r)
+		out = flattenCMS(target, r)
 	case *scan.SecurityTrailsResult:
-		return flattenSecurityTrails(target, r)
+		out = flattenSecurityTrails(target, r)
 	case *scan.CORSResult:
-		return flattenCORS(target, r)
+		out = flattenCORS(target, r)
 	case *scan.RedirectResult:
-		return flattenRedirect(target, r)
+		out = flattenRedirect(target, r)
 	case *scan.XSSResult:
-		return flattenXSS(target, r)
+		out = flattenXSS(target, r)
 	case *scan.CrawlResult:
-		return flattenCrawl(target, r)
+		out = flattenCrawl(target, r)
 	case *scan.PassiveResult:
-		return flattenPassive(target, r)
+		out = flattenPassive(target, r)
 	case *scan.ProbeResult:
-		return flattenProbe(target, r)
+		out = flattenProbe(target, r)
 	case scan.HeaderResults:
-		return flattenHeaders(target, r)
+		out = flattenHeaders(target, r)
 	case []scan.HeaderResult:
 		// the headers module appends a literal []HeaderResult, not the named
 		// slice type; both reach here so cover both.
-		return flattenHeaders(target, r)
+		out = flattenHeaders(target, r)
 	case scan.SecurityHeaderResults:
-		return flattenSecurityHeaders(target, r)
+		out = flattenSecurityHeaders(target, r)
 	case []scan.SecurityHeaderResult:
-		return flattenSecurityHeaders(target, r)
+		out = flattenSecurityHeaders(target, r)
 	case scan.DirectoryResults:
-		return flattenDirlist(target, r)
+		out = flattenDirlist(target, r)
 	case []scan.DirectoryResult:
-		return flattenDirlist(target, r)
+		out = flattenDirlist(target, r)
 	case scan.CloudStorageResults:
-		return flattenCloudStorage(target, r)
+		out = flattenCloudStorage(target, r)
 	case []scan.CloudStorageResult:
-		return flattenCloudStorage(target, r)
+		out = flattenCloudStorage(target, r)
 	case scan.DorkResults:
-		return flattenDork(target, r)
+		out = flattenDork(target, r)
 	case []scan.DorkResult:
-		return flattenDork(target, r)
+		out = flattenDork(target, r)
 	case scan.SubdomainTakeoverResults:
-		return flattenTakeover(target, r)
+		out = flattenTakeover(target, r)
 	case []scan.SubdomainTakeoverResult:
-		return flattenTakeover(target, r)
+		out = flattenTakeover(target, r)
 	case *frameworks.FrameworkResult:
-		return flattenFramework(target, r)
+		out = flattenFramework(target, r)
 	case *js.JavascriptScanResult:
-		return flattenJS(target, r)
+		out = flattenJS(target, r)
 	case *modules.Result:
 		// yaml/builtin modules carry their own module id; honor it over the
 		// passed-in module so per-module findings stay attributed correctly.
-		return flattenModule(target, r)
+		out = flattenModule(target, r)
 	case []output.ResultEvent:
-		return flattenNuclei(target, r)
+		out = flattenNuclei(target, r)
 	case []string:
 		// dnslist/portscan/git all hand back a bare []string of discovered
 		// items; module disambiguates which inventory it is.
-		return flattenStrings(target, module, r)
+		out = flattenStrings(target, module, r)
 	default:
 		// unknown type: emit a loud placeholder rather than dropping it.
-		return []Finding{{
+		out = []Finding{{
 			Target:   target,
 			Module:   module,
 			Severity: SeverityUnknown,
@@ -163,6 +165,10 @@ func Flatten(target, module string, result any) []Finding {
 			Raw:      fmt.Sprintf("%T", result),
 		}}
 	}
+	// some flatten* funcs iterate a Go map (js env vars), which randomizes
+	// order per run; sort by Key here once so all report output is stable.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
 }
 
 func flattenShodan(target string, r *scan.ShodanResult) []Finding {
@@ -478,11 +484,14 @@ func flattenHeaders(target string, rs []scan.HeaderResult) []Finding {
 	out := make([]Finding, 0, len(rs))
 	for i := 0; i < len(rs); i++ {
 		h := rs[i]
+		// a multi-valued header (Set-Cookie is the canonical case) emits one
+		// HeaderResult per value; the value must ride in the identifier or
+		// every value but the first collapses onto one dedup Key.
 		out = append(out, Finding{
 			Target:   target,
 			Module:   "headers",
 			Severity: sevRecon,
-			Key:      key("headers", h.Name),
+			Key:      key("headers", h.Name+":"+h.Value),
 			Title:    h.Name,
 			Raw:      h.Value,
 		})
@@ -665,8 +674,7 @@ func flattenJS(target string, r *js.JavascriptScanResult) []Finding {
 			Raw:      e,
 		})
 	}
-	// env vars are a map; sort-free since the Key carries the name, and diff
-	// keys on the Key not on iteration order.
+	// map order is random here; Flatten sorts by Key (see comment above sort.SliceStable).
 	for name, value := range r.FoundEnvironmentVars {
 		out = append(out, Finding{
 			Target:   target,

--- a/internal/finding/finding_test.go
+++ b/internal/finding/finding_test.go
@@ -335,7 +335,7 @@ func TestFlattenStableKeysAndSeverities(t *testing.T) {
 			name:    "header is recon info",
 			value:   scan.HeaderResults{{Name: "Server", Value: "nginx"}},
 			module:  "headers",
-			wantKey: "headers:Server:nginx",
+			wantKey: "headers:Server",
 			wantSev: SeverityInfo,
 		},
 		{
@@ -414,6 +414,66 @@ func TestMultiValuedHeaderGetsDistinctKeys(t *testing.T) {
 	}
 	if fs[0].Key == fs[1].Key {
 		t.Fatalf("distinct header values %q and %q share dedup Key %q", fs[0].Raw, fs[1].Raw, fs[0].Key)
+	}
+}
+
+// Key is documented to be run-stable, so a header whose value changes every
+// response (Date is on nearly all of them, plus ETag/Age/CF-Ray/X-Request-Id)
+// must keep the same Key across scans. folding the value into the key would
+// churn a fresh key each run and make the diff/notify layer report every such
+// header as added+removed on every scan of every target.
+func TestVolatileHeaderKeyIsRunStable(t *testing.T) {
+	run1 := Flatten(target, "headers", []scan.HeaderResult{{Name: "Date", Value: "Mon, 07 Jul 2026 12:00:00 GMT"}})
+	run2 := Flatten(target, "headers", []scan.HeaderResult{{Name: "Date", Value: "Mon, 07 Jul 2026 12:00:01 GMT"}})
+	if run1[0].Key != run2[0].Key {
+		t.Fatalf("Date key churned across runs: %q then %q", run1[0].Key, run2[0].Key)
+	}
+}
+
+// the slice position of a header is randomized per run, so the disambiguator
+// must count occurrences within a name rather than use the slice index.
+func TestHeaderKeyIndependentOfEmissionOrder(t *testing.T) {
+	cookieA := scan.HeaderResult{Name: "Set-Cookie", Value: "session=aaa"}
+	cookieB := scan.HeaderResult{Name: "Set-Cookie", Value: "tracking=bbb"}
+	server := scan.HeaderResult{Name: "Server", Value: "nginx"}
+	date := scan.HeaderResult{Name: "Date", Value: "Mon, 07 Jul 2026 12:00:00 GMT"}
+
+	keysFor := func(rs []scan.HeaderResult) map[string]string {
+		got := make(map[string]string)
+		for _, f := range Flatten(target, "headers", rs) {
+			got[f.Raw] = f.Key
+		}
+		return got
+	}
+
+	// same headers, the map handed them to us in a different order.
+	first := keysFor([]scan.HeaderResult{server, cookieA, cookieB, date})
+	second := keysFor([]scan.HeaderResult{date, cookieA, cookieB, server})
+
+	for value, key := range first {
+		if second[value] != key {
+			t.Errorf("header %q key changed with emission order: %q then %q", value, key, second[value])
+		}
+	}
+	if first["session=aaa"] == first["tracking=bbb"] {
+		t.Fatalf("the two Set-Cookie values still share key %q", first["session=aaa"])
+	}
+}
+
+// the occurrence suffix must use a separator that cannot appear in a header
+// field-name, or it collides with a real header of that literal name.
+func TestHeaderOccurrenceSuffixCannotCollide(t *testing.T) {
+	fs := Flatten(target, "headers", []scan.HeaderResult{
+		{Name: "Foo", Value: "first"},
+		{Name: "Foo", Value: "second"},
+		{Name: "Foo#1", Value: "a genuinely different header"},
+	})
+	seen := make(map[string]string, len(fs))
+	for _, f := range fs {
+		if prev, dup := seen[f.Key]; dup {
+			t.Errorf("key collision on %q: %q and %q", f.Key, prev, f.Raw)
+		}
+		seen[f.Key] = f.Raw
 	}
 }
 

--- a/internal/finding/finding_test.go
+++ b/internal/finding/finding_test.go
@@ -335,7 +335,7 @@ func TestFlattenStableKeysAndSeverities(t *testing.T) {
 			name:    "header is recon info",
 			value:   scan.HeaderResults{{Name: "Server", Value: "nginx"}},
 			module:  "headers",
-			wantKey: "headers:Server",
+			wantKey: "headers:Server:nginx",
 			wantSev: SeverityInfo,
 		},
 		{
@@ -400,5 +400,41 @@ func TestDeadProbeIsNotAFinding(t *testing.T) {
 	findings := Flatten(target, "probe", &scan.ProbeResult{URL: "http://x", Alive: false})
 	if len(findings) != 0 {
 		t.Errorf("dead probe produced %d findings, want 0", len(findings))
+	}
+}
+
+func TestMultiValuedHeaderGetsDistinctKeys(t *testing.T) {
+	hdrs := []scan.HeaderResult{
+		{Name: "Set-Cookie", Value: "session=aaa; HttpOnly"},
+		{Name: "Set-Cookie", Value: "tracking=bbb"},
+	}
+	fs := Flatten(target, "headers", hdrs)
+	if len(fs) != 2 {
+		t.Fatalf("flatten len = %d, want 2", len(fs))
+	}
+	if fs[0].Key == fs[1].Key {
+		t.Fatalf("distinct header values %q and %q share dedup Key %q", fs[0].Raw, fs[1].Raw, fs[0].Key)
+	}
+}
+
+func TestJSEnvVarOrderingIsStable(t *testing.T) {
+	res := &js.JavascriptScanResult{
+		FoundEnvironmentVars: map[string]string{
+			"A_KEY": "1", "B_KEY": "2", "C_KEY": "3",
+			"D_KEY": "4", "E_KEY": "5", "F_KEY": "6",
+		},
+	}
+
+	orderings := make(map[string]struct{})
+	for i := 0; i < 200; i++ {
+		fs := Flatten(target, "js", res)
+		keys := make([]string, 0, len(fs))
+		for _, f := range fs {
+			keys = append(keys, f.Key)
+		}
+		orderings[strings.Join(keys, ",")] = struct{}{}
+	}
+	if len(orderings) != 1 {
+		t.Errorf("Flatten produced %d distinct env-var orderings over 200 runs, want 1", len(orderings))
 	}
 }


### PR DESCRIPTION
header findings were deduped by name alone, so two Set-Cookie (or other multi-valued) headers with different values collapsed onto one finding.

the key now disambiguates by how many times the header name has been seen, not by the value. Key is documented to be run-stable (finding.go:41), and folding the value in would destabilize every volatile single-valued header: Date rides on nearly every response, alongside ETag, Age, CF-Ray and X-Request-Id, so each scan would mint a fresh key and the diff/notify layer would report them added+removed every run.

the count is per name rather than the slice index: headers.go ranges over resp.Header, so a name's slice position is randomized per run while the order of values within one name is preserved.

Flatten's output is also sorted by key, since several flatten paths (in particular the JS env-var map) source from randomized Go map iteration and produced a different finding order on every run.
