### PR TITLE
fix(modules): guard regex extractor against negative group index

### DIFF
--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -487,7 +487,7 @@ func runExtractors(extractors []Extractor, resp *http.Response, body string) map
 					continue
 				}
 				matches := re.FindStringSubmatch(part)
-				if len(matches) > e.Group {
+				if e.Group >= 0 && len(matches) > e.Group {
 					result[e.Name] = matches[e.Group]
 					break
 				}

--- a/internal/modules/matchers_test.go
+++ b/internal/modules/matchers_test.go
@@ -334,6 +334,14 @@ func TestRunExtractors(t *testing.T) {
 			wantNil: true,
 		},
 		{
+			// a negative group must be skipped, not panic on matches[-1].
+			name: "negative group is skipped",
+			extractors: []Extractor{
+				{Type: "regex", Name: "session", Part: "body", Regex: []string{`"session":"([^"]+)"`}, Group: -1},
+			},
+			wantNil: true,
+		},
+		{
 			name: "invalid pattern is skipped, no capture",
 			extractors: []Extractor{
 				{Type: "regex", Name: "session", Part: "body", Regex: []string{`(`}, Group: 1},


### PR DESCRIPTION
a module's extractor group is a plain int sourced straight from its yaml definition, so a module setting group: -1 hit matches[-1] and panicked at runtime. skip negative groups instead of indexing into the match slice.