### PR TITLE
fix(scan): decode html entities in probe title

### DIFF
--- a/internal/scan/probe.go
+++ b/internal/scan/probe.go
@@ -15,6 +15,7 @@ package scan
 import (
 	"context"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"regexp"
@@ -133,13 +134,14 @@ func Probe(targetURL string, timeout time.Duration, logdir string) (*ProbeResult
 }
 
 // extractTitle returns the trimmed text of the first <title> in body, or "" when
-// there isn't one.
+// there isn't one. html entities are decoded so the title matches the rendered
+// page rather than carrying raw "&amp;"-style markup.
 func extractTitle(body []byte) string {
 	m := titleRe.FindSubmatch(body)
 	if len(m) < 2 {
 		return ""
 	}
-	return strings.TrimSpace(string(m[1]))
+	return strings.TrimSpace(html.UnescapeString(string(m[1])))
 }
 
 // ResultType identifies probe results for the result registry.

--- a/internal/scan/probe_test.go
+++ b/internal/scan/probe_test.go
@@ -108,6 +108,7 @@ func TestProbe_ExtractTitle(t *testing.T) {
 		{"trimmed", "<title>  spaced  </title>", "spaced"},
 		{"attrs", `<title lang="en">attr</title>`, "attr"},
 		{"multiline", "<title>line one\nline two</title>", "line one\nline two"},
+		{"entities", "<title>Tom &amp; Jerry &#8211; Home</title>", "Tom & Jerry – Home"},
 		{"none", "<html><body>no title</body></html>", ""},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
the probe's extracted page title carried raw html entities (Tom &amp;amp; Jerry) instead of the decoded text a browser would render, since there was no entity-decoding step after pulling the <title> text out. decode entities so the title matches the rendered page.