### PR TITLE
feat(modules): add fingerprint module type

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -65,7 +65,8 @@ info:
 
 ### type (required)
 
-module type. `http` and `tcp` are supported.
+module type. `http` (request and match), `tcp` (raw connection probe) and
+`fingerprint` (weighted technology detection) are supported.
 
 ```yaml
 type: http
@@ -391,6 +392,44 @@ extractors:
       - "version"
       - "data.version"
 ```
+
+## fingerprint modules
+
+a `fingerprint` module identifies a technology by weighted signatures rather
+than a pass/fail match. each signature contributes its `weight` when it appears
+in the body (or, with `header: true`, in a response header name or value). the
+matched fraction of the total weight is the confidence; the module fires a
+single finding, carrying that confidence, once it reaches the threshold.
+
+this is the same scoring the built-in framework detectors use, in the module
+format, so a custom technology fingerprint lives alongside your other modules.
+
+```yaml
+id: acme-server
+info:
+  name: ACME Server
+  author: you
+  severity: info
+  tags: [tech, fingerprint]
+
+type: fingerprint
+
+fingerprint:
+  path: /                  # request path, defaults to /
+  confidence: 0.5          # minimum score to fire, defaults to 0.5
+  signatures:
+    - pattern: "acme"      # matched against header name/value
+      weight: 0.6
+      header: true
+    - pattern: "powered by acme"
+      weight: 0.4          # body match; omit weight to default to 1
+  version:                 # optional: pull a version out of the body
+    regex: "acme/([0-9.]+)"
+    group: 1
+```
+
+a response with both signatures scores `1.0`; the header alone scores `0.6` and
+still clears the `0.5` threshold, while the body alone (`0.4`) does not.
 
 ## examples
 

--- a/internal/modules/fingerprint.go
+++ b/internal/modules/fingerprint.go
@@ -1,0 +1,196 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/vmfunc/sif/internal/httpx"
+)
+
+// FingerprintConfig defines a framework-fingerprint module: weighted body/header
+// signatures scored into a confidence, plus an optional version regex. It mirrors
+// the framework custom-detector format so user fingerprints and modules can share
+// one loader and directory.
+type FingerprintConfig struct {
+	Path       string        `yaml:"path,omitempty"`       // request path, default "/"
+	Confidence float32       `yaml:"confidence,omitempty"` // min score to fire, default 0.5
+	Signatures []FPSignature `yaml:"signatures"`
+	Version    *FPVersion    `yaml:"version,omitempty"`
+}
+
+// FPSignature is one weighted pattern. Header matches the response headers (name
+// or value, case-insensitive) instead of the body.
+type FPSignature struct {
+	Pattern string  `yaml:"pattern"`
+	Weight  float32 `yaml:"weight"`
+	Header  bool    `yaml:"header"`
+}
+
+// FPVersion pulls a version string out of the body via a capture group.
+type FPVersion struct {
+	Regex string `yaml:"regex"`
+	Group int    `yaml:"group"`
+}
+
+// defaultFingerprintConfidence is the score a fingerprint must reach to fire when
+// the module does not set its own threshold.
+const defaultFingerprintConfidence = 0.5
+
+// validateFingerprint rejects a fingerprint config that can never produce a
+// meaningful score, so a broken module fails at load instead of silently never
+// matching. An omitted signature weight defaults to 1, so 0 is allowed.
+func validateFingerprint(cfg *FingerprintConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("missing fingerprint configuration")
+	}
+	if len(cfg.Signatures) == 0 {
+		return fmt.Errorf("fingerprint requires at least one signature")
+	}
+	for i, s := range cfg.Signatures {
+		if s.Pattern == "" {
+			return fmt.Errorf("signature %d has an empty pattern", i+1)
+		}
+		if s.Weight < 0 || math.IsInf(float64(s.Weight), 0) || math.IsNaN(float64(s.Weight)) {
+			return fmt.Errorf("signature %q needs a non-negative, finite weight", s.Pattern)
+		}
+	}
+	if cfg.Confidence < 0 || cfg.Confidence > 1 {
+		return fmt.Errorf("confidence must be within [0, 1]")
+	}
+	if cfg.Version != nil {
+		if cfg.Version.Group < 0 {
+			return fmt.Errorf("version group must be >= 0")
+		}
+		if _, err := regexp.Compile(cfg.Version.Regex); err != nil {
+			return fmt.Errorf("version regex: %w", err)
+		}
+	}
+	return nil
+}
+
+// ExecuteFingerprintModule fetches the target and scores it against the weighted
+// signatures, firing a single finding (with confidence and any version) once the
+// score reaches the threshold. The boolean matcher engine is not involved.
+func ExecuteFingerprintModule(ctx context.Context, target string, def *YAMLModule, opts Options) (*Result, error) {
+	cfg := def.Fingerprint
+	if cfg == nil {
+		return nil, fmt.Errorf("no fingerprint configuration")
+	}
+	result := &Result{ModuleID: def.ID, Target: target, Findings: make([]Finding, 0)}
+
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: opts.Timeout}
+	}
+
+	path := cfg.Path
+	if path == "" {
+		path = "/"
+	}
+	url := strings.TrimSuffix(target, "/") + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// an unreachable target is simply no finding, not a module failure.
+		return result, nil //nolint:nilerr // mirrors the http executor's swallow-per-request policy
+	}
+	defer resp.Body.Close()
+
+	body, err := httpx.ReadCappedBody(resp)
+	if err != nil {
+		return result, nil //nolint:nilerr // a body read error yields no finding, same as above
+	}
+	bodyStr := string(body)
+
+	score, version := scoreFingerprint(cfg, bodyStr, resp.Header)
+	threshold := cfg.Confidence
+	if threshold == 0 {
+		threshold = defaultFingerprintConfidence
+	}
+	if score < threshold {
+		return result, nil
+	}
+
+	finding := Finding{
+		URL:        url,
+		Severity:   def.Info.Severity,
+		Evidence:   truncateEvidence(bodyStr),
+		Confidence: score,
+	}
+	if version != "" {
+		finding.Extracted = map[string]string{"version": version}
+	}
+	result.Findings = append(result.Findings, finding)
+	return result, nil
+}
+
+// scoreFingerprint returns the matched fraction of signature weight and, when a
+// version regex is set and the body matches, the captured version.
+func scoreFingerprint(cfg *FingerprintConfig, body string, headers http.Header) (float32, string) {
+	var matched, total float32
+	for _, s := range cfg.Signatures {
+		w := s.Weight
+		if w == 0 {
+			w = 1
+		}
+		total += w
+		if s.Header {
+			if headerContains(headers, s.Pattern) {
+				matched += w
+			}
+		} else if strings.Contains(body, s.Pattern) {
+			matched += w
+		}
+	}
+	if total == 0 {
+		return 0, ""
+	}
+	score := matched / total
+
+	version := ""
+	if cfg.Version != nil && score > 0 {
+		if re, err := regexp.Compile(cfg.Version.Regex); err == nil {
+			if g := re.FindStringSubmatch(body); len(g) > cfg.Version.Group {
+				version = g[cfg.Version.Group]
+			}
+		}
+	}
+	return score, version
+}
+
+// headerContains reports whether pattern appears in any header name or value,
+// case-insensitively, matching the framework detector's header semantics.
+func headerContains(headers http.Header, pattern string) bool {
+	p := strings.ToLower(pattern)
+	for name, values := range headers {
+		if strings.Contains(strings.ToLower(name), p) {
+			return true
+		}
+		for _, v := range values {
+			if strings.Contains(strings.ToLower(v), p) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/modules/fingerprint_parse_test.go
+++ b/internal/modules/fingerprint_parse_test.go
@@ -1,0 +1,170 @@
+package modules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeFingerprintFile(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "fp.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write module: %v", err)
+	}
+	return p
+}
+
+const fingerprintYAML = `
+id: acme-server
+info:
+  name: ACME Server
+  severity: info
+type: fingerprint
+fingerprint:
+  path: /
+  confidence: 0.5
+  signatures:
+    - pattern: "acme"
+      weight: 0.6
+      header: true
+    - pattern: "powered by acme"
+      weight: 0.4
+  version:
+    regex: "acme/([0-9.]+)"
+    group: 1
+`
+
+// Parse a fingerprint module from real YAML and run it through the module
+// wrapper's dispatch, exercising parse -> validate -> Execute end to end.
+func TestFingerprintParseRoundTrip(t *testing.T) {
+	def, err := ParseYAMLModule(writeFingerprintFile(t, fingerprintYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if def.Type != TypeFingerprint {
+		t.Fatalf("type = %q, want fingerprint", def.Type)
+	}
+	if def.Fingerprint == nil || len(def.Fingerprint.Signatures) != 2 {
+		t.Fatalf("fingerprint config not parsed: %+v", def.Fingerprint)
+	}
+	if !def.Fingerprint.Signatures[0].Header {
+		t.Errorf("first signature should be header-scoped")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "acme/3.1")
+		_, _ = w.Write([]byte("powered by acme/3.1"))
+	}))
+	defer srv.Close()
+
+	mod := newYAMLModuleWrapper(def, "fp.yaml")
+	res, err := mod.Execute(context.Background(), srv.URL, Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(res.Findings))
+	}
+	if got := res.Findings[0].Confidence; got < 0.99 {
+		t.Errorf("confidence = %v, want ~1.0 (both signatures match)", got)
+	}
+	if got := res.Findings[0].Extracted["version"]; got != "3.1" {
+		t.Errorf("version = %q, want 3.1", got)
+	}
+}
+
+func TestFingerprintValidation(t *testing.T) {
+	cases := map[string]string{
+		"no signatures": `id: m
+type: fingerprint
+fingerprint:
+  signatures: []`,
+		"empty pattern": `id: m
+type: fingerprint
+fingerprint:
+  signatures:
+    - pattern: ""
+      weight: 1`,
+		"negative weight": `id: m
+type: fingerprint
+fingerprint:
+  signatures:
+    - pattern: x
+      weight: -1`,
+		"confidence over 1": `id: m
+type: fingerprint
+fingerprint:
+  confidence: 1.5
+  signatures:
+    - pattern: x
+      weight: 1`,
+		"bad version regex": `id: m
+type: fingerprint
+fingerprint:
+  signatures:
+    - pattern: x
+      weight: 1
+  version:
+    regex: "([0-9"
+    group: 1`,
+		"negative version group": `id: m
+type: fingerprint
+fingerprint:
+  signatures:
+    - pattern: x
+      weight: 1
+  version:
+    regex: "(x)"
+    group: -1`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseYAMLModule(writeFingerprintFile(t, body)); err == nil {
+				t.Fatalf("expected a validation error for %q, got nil", name)
+			}
+		})
+	}
+}
+
+// An omitted confidence threshold falls back to defaultFingerprintConfidence.
+func TestFingerprintDefaultConfidence(t *testing.T) {
+	cfg := &FingerprintConfig{
+		Signatures: []FPSignature{
+			{Pattern: "hit", Weight: 1},
+			{Pattern: "miss-me", Weight: 1},
+		},
+	}
+	def := &YAMLModule{ID: "m", Type: TypeFingerprint, Info: YAMLModuleInfo{Severity: "info"}, Fingerprint: cfg}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("only hit is here")) // 1 of 2 -> score 0.5 == default threshold
+	}))
+	defer srv.Close()
+
+	res, err := ExecuteFingerprintModule(context.Background(), srv.URL, def, Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("score 0.5 should clear the default 0.5 threshold; got %d findings", len(res.Findings))
+	}
+
+	// A target matching nothing scores 0 and stays silent.
+	blank := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", 8)))
+	}))
+	defer blank.Close()
+	res2, err := ExecuteFingerprintModule(context.Background(), blank.URL, def, Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute blank: %v", err)
+	}
+	if len(res2.Findings) != 0 {
+		t.Fatalf("no signatures match -> want 0 findings, got %d", len(res2.Findings))
+	}
+}

--- a/internal/modules/fingerprint_type_test.go
+++ b/internal/modules/fingerprint_type_test.go
@@ -1,0 +1,60 @@
+package modules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fpTypeModule is a fingerprint expressed as its own module type: three weighted
+// signatures (0.5 + 0.3 + 0.2) plus a version regex.
+func fpTypeModule(confidence float32) *YAMLModule {
+	return &YAMLModule{
+		ID:   "fp-test",
+		Type: TypeFingerprint,
+		Info: YAMLModuleInfo{Severity: "info"},
+		Fingerprint: &FingerprintConfig{
+			Confidence: confidence,
+			Signatures: []FPSignature{
+				{Pattern: "alpha", Weight: 0.5},
+				{Pattern: "beta", Weight: 0.3},
+				{Pattern: "gamma", Weight: 0.2},
+			},
+			Version: &FPVersion{Regex: `alpha/(\d+\.\d+)`, Group: 1},
+		},
+	}
+}
+
+func TestFingerprintTypeScoring(t *testing.T) {
+	// body matches alpha (0.5) + beta (0.3) = 0.8 of total weight; gamma absent.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("banner: alpha/2.4 and beta present"))
+	}))
+	defer srv.Close()
+
+	opts := Options{Timeout: 5 * time.Second, Threads: 1}
+
+	res, err := ExecuteFingerprintModule(context.Background(), srv.URL, fpTypeModule(0.5), opts)
+	if err != nil {
+		t.Fatalf("execute at 0.5: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("threshold 0.5: want 1 finding, got %d", len(res.Findings))
+	}
+	if got := res.Findings[0].Confidence; got < 0.79 || got > 0.81 {
+		t.Errorf("confidence = %v, want ~0.8", got)
+	}
+	if got := res.Findings[0].Extracted["version"]; got != "2.4" {
+		t.Errorf("version = %q, want 2.4", got)
+	}
+
+	res2, err := ExecuteFingerprintModule(context.Background(), srv.URL, fpTypeModule(0.9), opts)
+	if err != nil {
+		t.Fatalf("execute at 0.9: %v", err)
+	}
+	if len(res2.Findings) != 0 {
+		t.Fatalf("threshold 0.9: want 0 findings (score 0.8 < 0.9), got %d", len(res2.Findings))
+	}
+}

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -25,10 +25,11 @@ import (
 type ModuleType string
 
 const (
-	TypeHTTP   ModuleType = "http"
-	TypeDNS    ModuleType = "dns"
-	TypeTCP    ModuleType = "tcp"
-	TypeScript ModuleType = "script"
+	TypeHTTP        ModuleType = "http"
+	TypeDNS         ModuleType = "dns"
+	TypeTCP         ModuleType = "tcp"
+	TypeScript      ModuleType = "script"
+	TypeFingerprint ModuleType = "fingerprint"
 )
 
 // Module is the interface all modules implement.
@@ -77,10 +78,11 @@ func (r *Result) ResultType() string {
 
 // Finding represents a discovered issue.
 type Finding struct {
-	URL       string            `json:"url,omitempty"`
-	Severity  string            `json:"severity"`
-	Evidence  string            `json:"evidence,omitempty"`
-	Extracted map[string]string `json:"extracted,omitempty"`
+	URL        string            `json:"url,omitempty"`
+	Severity   string            `json:"severity"`
+	Evidence   string            `json:"evidence,omitempty"`
+	Extracted  map[string]string `json:"extracted,omitempty"`
+	Confidence float32           `json:"confidence,omitempty"` // set only for fingerprint modules
 }
 
 // Matcher defines matching logic for module responses.

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -34,12 +34,13 @@ import (
 
 // YAMLModule represents a parsed YAML module file
 type YAMLModule struct {
-	ID   string         `yaml:"id"`
-	Info YAMLModuleInfo `yaml:"info"`
-	Type ModuleType     `yaml:"type"`
-	HTTP *HTTPConfig    `yaml:"http,omitempty"`
-	DNS  *DNSConfig     `yaml:"dns,omitempty"`
-	TCP  *TCPConfig     `yaml:"tcp,omitempty"`
+	ID          string             `yaml:"id"`
+	Info        YAMLModuleInfo     `yaml:"info"`
+	Type        ModuleType         `yaml:"type"`
+	HTTP        *HTTPConfig        `yaml:"http,omitempty"`
+	DNS         *DNSConfig         `yaml:"dns,omitempty"`
+	TCP         *TCPConfig         `yaml:"tcp,omitempty"`
+	Fingerprint *FingerprintConfig `yaml:"fingerprint,omitempty"`
 }
 
 // YAMLModuleInfo contains module metadata
@@ -165,6 +166,12 @@ func ParseYAMLModuleBytes(data []byte) (*YAMLModule, error) {
 		return nil, fmt.Errorf("module %q: %w", ym.ID, err)
 	}
 
+	if ym.Type == TypeFingerprint {
+		if err := validateFingerprint(ym.Fingerprint); err != nil {
+			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
+		}
+	}
+
 	return &ym, nil
 }
 
@@ -214,6 +221,11 @@ func (m *yamlModuleWrapper) Execute(ctx context.Context, target string, opts Opt
 			return nil, fmt.Errorf("TCP module missing tcp configuration")
 		}
 		return ExecuteTCPModule(ctx, target, m.def, opts)
+	case TypeFingerprint:
+		if m.def.Fingerprint == nil {
+			return nil, fmt.Errorf("fingerprint module missing fingerprint configuration")
+		}
+		return ExecuteFingerprintModule(ctx, target, m.def, opts)
 	default:
 		return nil, fmt.Errorf("unsupported module type: %s", m.def.Type)
 	}


### PR DESCRIPTION
a fingerprint module identifies a technology by weighted body/header signatures scored into a confidence, with an optional version regex, rather than a boolean match. it fires one finding carrying the score once it reaches the threshold (default 0.5) - the framework detectors' scoring approach, in the module format, so a custom tech fingerprint can live alongside other modules. validated at load (signatures present, non-empty patterns, finite weights, confidence in [0,1], version regex compiles) and covered by yaml round-trip, validation, header, version and default-threshold tests. documented in docs/modules.md.

depends on #355: the first two commits here are that PR's shared sifpath/httpx helpers (fingerprint.go uses httpx.ReadCappedBody), included so this branch builds standalone. once #355 merges, rebasing this one should drop those two commits as already-applied and leave only the fingerprint commit.