### PR TITLE
feat(modules): bridge fingerprint modules into framework detection

### DIFF
--- a/internal/modules/bridge.go
+++ b/internal/modules/bridge.go
@@ -1,0 +1,123 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/charmbracelet/log"
+	"github.com/vmfunc/sif/internal/scan/frameworks"
+)
+
+// bridgeableToFramework reports whether def is a fingerprint whose semantics
+// the framework engine can reproduce exactly: root path, default confidence,
+// all weights > 0. anything else stays module-only. the two engines still
+// disagree at score == 0.5 (>= confidence vs > detectionThreshold).
+func bridgeableToFramework(def *YAMLModule) (bool, string) {
+	if def.Type != TypeFingerprint || def.Fingerprint == nil {
+		return false, "not a fingerprint module"
+	}
+	cfg := def.Fingerprint
+	if cfg.Path != "" && cfg.Path != "/" {
+		return false, "non-root path"
+	}
+	if cfg.Confidence != 0 {
+		return false, "custom confidence"
+	}
+	for _, s := range cfg.Signatures {
+		if s.Weight <= 0 {
+			return false, "zero-weight signature"
+		}
+	}
+	return true, ""
+}
+
+// bridgeFingerprint registers def as a framework detector when
+// bridgeableToFramework allows it, and reports whether it registered. a guard
+// failure is not an error: the module still runs natively in the module
+// engine, so bridging is pure upside or a no-op.
+func bridgeFingerprint(def *YAMLModule) (bool, string) {
+	ok, reason := bridgeableToFramework(def)
+	if !ok {
+		return false, reason
+	}
+
+	cfg := def.Fingerprint
+	sigs := make([]frameworks.Signature, len(cfg.Signatures))
+	for i, s := range cfg.Signatures {
+		sigs[i] = frameworks.Signature{Pattern: s.Pattern, Weight: s.Weight, HeaderOnly: s.Header}
+	}
+
+	d := &bridgedDetector{BaseDetector: frameworks.NewBaseDetector(def.ID, sigs)}
+	if cfg.Version != nil {
+		if re, err := regexp.Compile(cfg.Version.Regex); err == nil {
+			d.versionRe = re
+			d.versionGroup = cfg.Version.Group
+		}
+	}
+
+	// the name comes from a user-controlled module id and frameworks.Register
+	// clobbers by name, so a module id matching a builtin ("WordPress",
+	// "Django") would silently replace that detector. refuse instead.
+	if !frameworks.RegisterIfAbsent(d) {
+		return false, "detector name already registered"
+	}
+	return true, ""
+}
+
+// bridgedDetector adapts a bridgeable fingerprint module into a
+// frameworks.Detector. structurally the same as frameworks' own (unexported)
+// customDetector; kept as a small local copy here rather than exporting that
+// type, since frameworks cannot import modules and this avoids an import cycle.
+type bridgedDetector struct {
+	frameworks.BaseDetector
+	versionRe    *regexp.Regexp
+	versionGroup int
+}
+
+// Detect mirrors customDetector.Detect (custom.go): the weighted signature
+// score plus an optional version capture.
+func (d *bridgedDetector) Detect(body string, headers http.Header) (float32, string) {
+	confidence := d.MatchSignatures(body, headers)
+	if confidence == 0 || d.versionRe == nil {
+		return confidence, ""
+	}
+	matches := d.versionRe.FindStringSubmatch(body)
+	if len(matches) > d.versionGroup {
+		return confidence, matches[d.versionGroup]
+	}
+	return confidence, ""
+}
+
+// BridgeFingerprints registers every loaded fingerprint module bridgeableToFramework
+// allows as a framework detector, and returns the ids it bridged. bridging never
+// alters a module's native execution; the returned set lets the caller drop those
+// ids from an implicit run so one technology isn't reported by both engines.
+func BridgeFingerprints() map[string]bool {
+	bridged := make(map[string]bool)
+	for _, m := range ByType(TypeFingerprint) {
+		w, ok := m.(*yamlModuleWrapper)
+		if !ok {
+			continue
+		}
+		def := w.definition()
+		ok, reason := bridgeFingerprint(def)
+		if ok {
+			bridged[def.ID] = true
+			continue
+		}
+		log.Debugf("fingerprint %s not bridged to framework detection: %s", def.ID, reason)
+	}
+	return bridged
+}

--- a/internal/modules/fingerprint_bridge_test.go
+++ b/internal/modules/fingerprint_bridge_test.go
@@ -1,0 +1,269 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"math/rand"
+	"net/http"
+	"testing"
+
+	"github.com/vmfunc/sif/internal/scan/frameworks"
+)
+
+// okFingerprintDef builds a root-path, default-confidence, all-positive-weight
+// fingerprint module: the one shape the framework engine can reproduce exactly
+// (the shared domain).
+func okFingerprintDef(id string) *YAMLModule {
+	return &YAMLModule{
+		ID:   id,
+		Type: TypeFingerprint,
+		Fingerprint: &FingerprintConfig{
+			Signatures: []FPSignature{
+				{Pattern: "nginx", Weight: 1},
+				{Pattern: "X-Powered-By", Weight: 2, Header: true},
+			},
+		},
+	}
+}
+
+func TestBridgeFingerprint_RootDefaultPositiveWeight_Registers(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-ok")
+
+	registered, reason := bridgeFingerprint(def)
+	if !registered {
+		t.Fatalf("bridgeFingerprint registered = false, reason %q, want true", reason)
+	}
+
+	det, ok := frameworks.GetDetector(def.ID)
+	if !ok {
+		t.Fatalf("frameworks.GetDetector(%q) not found after bridging", def.ID)
+	}
+
+	body := "served by nginx"
+	headers := http.Header{"X-Powered-By": {"PHP"}}
+	got, _ := det.Detect(body, headers)
+	want, _ := scoreFingerprint(def.Fingerprint, body, headers)
+	if got != want {
+		t.Fatalf("bridged Detect = %v, scoreFingerprint = %v, want equal", got, want)
+	}
+}
+
+func TestBridgeFingerprint_NonRootPath_Refuses(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-path")
+	def.Fingerprint.Path = "/admin"
+
+	registered, reason := bridgeFingerprint(def)
+	if registered {
+		t.Fatal("bridgeFingerprint registered a non-root fingerprint")
+	}
+	if reason == "" {
+		t.Fatal("expected a non-empty refusal reason")
+	}
+	if _, ok := frameworks.GetDetector(def.ID); ok {
+		t.Fatalf("frameworks.GetDetector(%q) found a detector that should have been refused", def.ID)
+	}
+}
+
+func TestBridgeFingerprint_CustomConfidence_Refuses(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-conf")
+	def.Fingerprint.Confidence = 0.7
+
+	registered, reason := bridgeFingerprint(def)
+	if registered {
+		t.Fatal("bridgeFingerprint registered a custom-confidence fingerprint")
+	}
+	if reason == "" {
+		t.Fatal("expected a non-empty refusal reason")
+	}
+	if _, ok := frameworks.GetDetector(def.ID); ok {
+		t.Fatalf("frameworks.GetDetector(%q) found a detector that should have been refused", def.ID)
+	}
+}
+
+// TestBridgeFingerprint_MatchesNativeAcrossSampledInputs proves the bridged
+// detector and the native module scorer agree on the shared domain, mirroring
+// TestScorerEquivalenceSharedDomain but through the bridge itself.
+func TestBridgeFingerprint_MatchesNativeAcrossSampledInputs(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-sampled")
+	registered, reason := bridgeFingerprint(def)
+	if !registered {
+		t.Fatalf("bridgeFingerprint registered = false, reason %q", reason)
+	}
+	det, ok := frameworks.GetDetector(def.ID)
+	if !ok {
+		t.Fatalf("frameworks.GetDetector(%q) not found after bridging", def.ID)
+	}
+
+	tokens := []string{"nginx", "X-Powered-By", "cloudflare", "wp-content"}
+	r := rand.New(rand.NewSource(2))
+	for iter := 0; iter < 500; iter++ {
+		body := ""
+		for _, tk := range tokens {
+			if r.Intn(2) == 0 {
+				body += tk + " "
+			}
+		}
+		headers := http.Header{}
+		for _, tk := range tokens {
+			if r.Intn(2) == 0 {
+				headers.Add(tk, "v")
+			}
+		}
+		got, _ := det.Detect(body, headers)
+		want, _ := scoreFingerprint(def.Fingerprint, body, headers)
+		if got != want {
+			t.Fatalf("iter %d: bridged=%v native=%v body=%q headers=%v", iter, got, want, body, headers)
+		}
+	}
+}
+
+// TestBridgeFingerprint_ExactlyHalfBoundaryDiverges pins the one documented
+// residual: on the shared domain the scores agree, but the module engine
+// fires at score >= threshold (inclusive) while the framework engine's gate
+// (detectionThreshold, applied by the caller as best.confidence <=
+// detectionThreshold) is exclusive of exactly 0.5. this test only pins the
+// score-equality half from inside the bridge; the exclusivity of the
+// framework gate itself is proven by TestFrameworkThresholdIsStrict.
+func TestBridgeFingerprint_ExactlyHalfBoundaryDiverges(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-half")
+	def.Fingerprint.Signatures = []FPSignature{
+		{Pattern: "hit", Weight: 1},
+		{Pattern: "miss", Weight: 1},
+	}
+	registered, reason := bridgeFingerprint(def)
+	if !registered {
+		t.Fatalf("bridgeFingerprint registered = false, reason %q", reason)
+	}
+	det, ok := frameworks.GetDetector(def.ID)
+	if !ok {
+		t.Fatalf("frameworks.GetDetector(%q) not found after bridging", def.ID)
+	}
+
+	body := "hit"
+	bridgedScore, _ := det.Detect(body, http.Header{})
+	if bridgedScore != 0.5 {
+		t.Fatalf("bridged score = %v, want exactly 0.5", bridgedScore)
+	}
+
+	nativeScore, _ := scoreFingerprint(def.Fingerprint, body, http.Header{})
+	if nativeScore != 0.5 {
+		t.Fatalf("native score = %v, want exactly 0.5", nativeScore)
+	}
+
+	// module engine: score >= threshold(0.5) fires (fingerprint.go:130).
+	moduleFires := nativeScore >= defaultFingerprintConfidence
+	if !moduleFires {
+		t.Fatal("module engine should fire at score == 0.5 (inclusive gate)")
+	}
+
+	// framework engine: DetectFramework/DetectFrameworks require
+	// confidence > detectionThreshold(0.5) (detect.go:133/168), so an exact
+	// 0.5 does not clear it even though the score itself matches.
+	const detectionThreshold = 0.5
+	frameworkFires := bridgedScore > detectionThreshold
+	if frameworkFires {
+		t.Fatal("framework engine should not fire at score == 0.5 (exclusive gate)")
+	}
+}
+
+func TestBridgeFingerprint_ZeroWeightSignature_Refuses(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-zero")
+	def.Fingerprint.Signatures = append(def.Fingerprint.Signatures, FPSignature{Pattern: "extra", Weight: 0})
+
+	registered, reason := bridgeFingerprint(def)
+	if registered {
+		t.Fatal("bridgeFingerprint registered a zero-weight-signature fingerprint")
+	}
+	if reason == "" {
+		t.Fatal("expected a non-empty refusal reason")
+	}
+	if _, ok := frameworks.GetDetector(def.ID); ok {
+		t.Fatalf("frameworks.GetDetector(%q) found a detector that should have been refused", def.ID)
+	}
+}
+
+// bridged names come from user-controlled module ids and frameworks.Register
+// clobbers by name, so a module id that collides with a builtin detector would
+// silently replace the builtin. the bridge must refuse instead.
+func TestBridgeFingerprint_ExistingDetectorName_Refuses(t *testing.T) {
+	const name = "fp-bridge-collision"
+	builtin := &bridgedDetector{BaseDetector: frameworks.NewBaseDetector(name, []frameworks.Signature{
+		{Pattern: "the-builtin-marker", Weight: 1},
+	})}
+	frameworks.Register(builtin)
+
+	def := okFingerprintDef(name)
+	registered, reason := bridgeFingerprint(def)
+	if registered {
+		t.Fatal("bridgeFingerprint overwrote an already-registered detector name")
+	}
+	if reason == "" {
+		t.Fatal("expected a non-empty refusal reason")
+	}
+
+	// the original detector must still be the one in the registry.
+	got, ok := frameworks.GetDetector(name)
+	if !ok {
+		t.Fatal("the pre-existing detector was removed from the registry")
+	}
+	if conf, _ := got.Detect("the-builtin-marker", http.Header{}); conf == 0 {
+		t.Error("the registered detector no longer matches the builtin marker, it was clobbered")
+	}
+}
+
+// BridgeFingerprints must report what it bridged so callers can tell which
+// modules the framework engine now covers.
+func TestBridgeFingerprintsReportsBridgedIDs(t *testing.T) {
+	ok := okFingerprintDef("fp-bridge-reported")
+	refused := okFingerprintDef("fp-bridge-not-reported")
+	refused.Fingerprint.Path = "/admin"
+	Register(&yamlModuleWrapper{def: ok})
+	Register(&yamlModuleWrapper{def: refused})
+
+	bridged := BridgeFingerprints()
+	if !bridged[ok.ID] {
+		t.Errorf("bridged set is missing %q", ok.ID)
+	}
+	if bridged[refused.ID] {
+		t.Errorf("bridged set contains refused module %q", refused.ID)
+	}
+}
+
+// the bridge is only worth anything if a bridged fingerprint actually
+// participates in framework detection, which is what a registered detector
+// buys. run the registered detector through the same scoring the framework
+// engine uses and require it to clear the reporting floor on a real body.
+func TestBridgedFingerprintScoresInFrameworkEngine(t *testing.T) {
+	def := okFingerprintDef("fp-bridge-scores")
+	Register(&yamlModuleWrapper{def: def})
+
+	if bridged := BridgeFingerprints(); !bridged[def.ID] {
+		t.Fatalf("%q was not bridged", def.ID)
+	}
+
+	det, ok := frameworks.GetDetector(def.ID)
+	if !ok {
+		t.Fatalf("no detector registered for %q", def.ID)
+	}
+
+	// both signatures present: the framework engine must see a full score.
+	conf, _ := det.Detect("served by nginx", http.Header{"X-Powered-By": {"PHP"}})
+	if conf != 1 {
+		t.Errorf("bridged detector scored %v on a full match, want 1", conf)
+	}
+
+	// nothing present: it must not invent a detection.
+	if conf, _ := det.Detect("static site", http.Header{}); conf != 0 {
+		t.Errorf("bridged detector scored %v on an unrelated response, want 0", conf)
+	}
+}

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -186,6 +186,12 @@ func newYAMLModuleWrapper(def *YAMLModule, path string) *yamlModuleWrapper {
 	return &yamlModuleWrapper{def: def, path: path}
 }
 
+// definition returns the wrapped YAMLModule so same-package callers (the
+// fingerprint bridge) can reach fields the Module interface does not expose.
+func (m *yamlModuleWrapper) definition() *YAMLModule {
+	return m.def
+}
+
 // Info returns the module metadata
 func (m *yamlModuleWrapper) Info() Info {
 	return Info{

--- a/internal/scan/frameworks/detector.go
+++ b/internal/scan/frameworks/detector.go
@@ -59,6 +59,19 @@ func Register(d Detector) {
 	registry[d.Name()] = d
 }
 
+// RegisterIfAbsent registers d only when its name is free, and reports whether
+// it did. Register clobbers by name, which a user-supplied module id must not do
+// to a builtin. check and insert share one lock.
+func RegisterIfAbsent(d Detector) bool {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, exists := registry[d.Name()]; exists {
+		return false
+	}
+	registry[d.Name()] = d
+	return true
+}
+
 // GetDetectors returns all registered detectors.
 func GetDetectors() map[string]Detector {
 	registryMu.RLock()

--- a/sif.go
+++ b/sif.go
@@ -48,6 +48,90 @@ type App struct {
 	settings *config.Settings
 	targets  []string
 	logFiles []string
+
+	// both are written once in Run before any scanTarget goroutine starts and
+	// only read afterwards, so the worker pool sees them without a lock.
+	modulesLoaded       bool
+	bridgedFingerprints map[string]bool
+}
+
+// loadModules populates the module registry once and is a no-op afterwards. it
+// must not be called from scanTarget: modulesLoaded is unguarded and that runs
+// on the worker pool. a loader that cannot be built is returned so -list-modules
+// stays fatal while a scan can downgrade it to a warning.
+func (app *App) loadModules() error {
+	if app.modulesLoaded {
+		return nil
+	}
+	loader, err := modules.NewLoader()
+	if err != nil {
+		return fmt.Errorf("failed to create module loader: %w", err)
+	}
+	if err := loader.LoadAll(); err != nil {
+		log.Warnf("Failed to load modules: %v", err)
+	}
+	builtin.Register()
+	app.modulesLoaded = true
+	return nil
+}
+
+// wantsModules reports whether this run needs the module registry populated,
+// either to run modules directly or to bridge fingerprints into framework
+// detection.
+func (app *App) wantsModules() bool {
+	return app.settings.Framework || app.settings.AllModules ||
+		app.settings.Modules != "" || app.settings.ModuleTags != ""
+}
+
+// selectModules resolves the module selection flags into the set to run for one
+// target. a bridged fingerprint is already reported by the framework engine, so
+// it is dropped from the implicit selections; naming it with -modules is a
+// direct request and still runs it.
+func (app *App) selectModules() []modules.Module {
+	var toRun []modules.Module
+	switch {
+	case app.settings.AllModules:
+		toRun = app.dropBridged(modules.All())
+	case app.settings.ModuleTags != "":
+		for _, tag := range strings.Split(app.settings.ModuleTags, ",") {
+			toRun = append(toRun, modules.ByTag(strings.TrimSpace(tag))...)
+		}
+		toRun = app.dropBridged(toRun)
+	case app.settings.Modules != "":
+		for _, id := range strings.Split(app.settings.Modules, ",") {
+			if m, ok := modules.Get(strings.TrimSpace(id)); ok {
+				toRun = append(toRun, m)
+			} else {
+				log.Warnf("Module not found: %s", id)
+			}
+		}
+	}
+
+	seen := make(map[string]bool, len(toRun))
+	deduped := make([]modules.Module, 0, len(toRun))
+	for _, m := range toRun {
+		if id := m.Info().ID; !seen[id] {
+			seen[id] = true
+			deduped = append(deduped, m)
+		}
+	}
+	return deduped
+}
+
+// dropBridged removes the modules framework detection already covers.
+func (app *App) dropBridged(ms []modules.Module) []modules.Module {
+	if len(app.bridgedFingerprints) == 0 {
+		return ms
+	}
+	out := make([]modules.Module, 0, len(ms))
+	for _, m := range ms {
+		if id := m.Info().ID; app.bridgedFingerprints[id] {
+			log.Debugf("Skipping %s: covered by framework detection", id)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // Version is set by main to the resolved build version and shown on the banner.
@@ -237,16 +321,9 @@ func normalizeTarget(target string) (string, error) {
 func (app *App) Run() error {
 	// Handle --list-modules before any other processing
 	if app.settings.ListModules {
-		loader, err := modules.NewLoader()
-		if err != nil {
-			return fmt.Errorf("failed to create module loader: %w", err)
+		if err := app.loadModules(); err != nil {
+			return err
 		}
-		if err := loader.LoadAll(); err != nil {
-			log.Warnf("Failed to load modules: %v", err)
-		}
-
-		// Register built-in Go modules
-		builtin.Register()
 
 		fmt.Println("Available modules:")
 		for _, m := range modules.All() {
@@ -321,6 +398,18 @@ func (app *App) Run() error {
 		} else {
 			storeDir = dir
 		}
+	}
+
+	// load once for the whole run and bridge before scanAllTargets: the
+	// per-target framework scan runs inside the worker pool, so a later
+	// registry write would both miss it and race.
+	if app.wantsModules() {
+		if err := app.loadModules(); err != nil {
+			log.Warnf("%v", err)
+		}
+	}
+	if app.settings.Framework {
+		app.bridgedFingerprints = modules.BridgeFingerprints()
 	}
 
 	results, err := app.scanAllTargets(storeDir, wantReport)
@@ -716,47 +805,12 @@ func (app *App) scanTarget(url, storeDir string, wantReport bool) (targetScan, e
 
 	// Load and run modules
 	if app.settings.AllModules || app.settings.Modules != "" || app.settings.ModuleTags != "" {
-		loader, err := modules.NewLoader()
-		if err != nil {
-			log.Warnf("Failed to create module loader: %v", err)
-		} else {
-			if err := loader.LoadAll(); err != nil {
-				log.Warnf("Failed to load modules: %v", err)
-			}
+		{
+			// the registry was populated once in Run; loading it per target
+			// would re-walk the module dirs on every url and, under
+			// -concurrency, from several workers at once.
+			toRun := app.selectModules()
 
-			// Register built-in Go modules
-			builtin.Register()
-
-			// Determine which modules to run
-			var toRun []modules.Module
-			switch {
-			case app.settings.AllModules:
-				toRun = modules.All()
-			case app.settings.ModuleTags != "":
-				for _, tag := range strings.Split(app.settings.ModuleTags, ",") {
-					toRun = append(toRun, modules.ByTag(strings.TrimSpace(tag))...)
-				}
-			case app.settings.Modules != "":
-				for _, id := range strings.Split(app.settings.Modules, ",") {
-					if m, ok := modules.Get(strings.TrimSpace(id)); ok {
-						toRun = append(toRun, m)
-					} else {
-						log.Warnf("Module not found: %s", id)
-					}
-				}
-			}
-
-			seen := make(map[string]bool, len(toRun))
-			deduped := make([]modules.Module, 0, len(toRun))
-			for _, m := range toRun {
-				if id := m.Info().ID; !seen[id] {
-					seen[id] = true
-					deduped = append(deduped, m)
-				}
-			}
-			toRun = deduped
-
-			// Execute modules
 			// Execute modules. Client routes through the shared httpx transport so
 			// -proxy/-H/-cookie/-rate-limit apply to module scans the same as every
 			// other scanner instead of each module dialing out on a bare client.

--- a/sif_bridge_dedup_test.go
+++ b/sif_bridge_dedup_test.go
@@ -1,0 +1,126 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package sif
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmfunc/sif/internal/config"
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+// stubModule is a registry entry with an id and tags and nothing else; these
+// tests only exercise selection, never execution.
+type stubModule struct {
+	id   string
+	tags []string
+}
+
+func (m stubModule) Info() modules.Info {
+	return modules.Info{ID: m.id, Name: m.id, Tags: m.tags}
+}
+func (m stubModule) Type() modules.ModuleType { return modules.TypeFingerprint }
+func (m stubModule) Execute(context.Context, string, modules.Options) (*modules.Result, error) {
+	return &modules.Result{}, nil
+}
+
+func ids(ms []modules.Module) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Info().ID)
+	}
+	return out
+}
+
+func has(ms []modules.Module, id string) bool {
+	for _, m := range ms {
+		if m.Info().ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// a bridged fingerprint is reported by the framework engine, so running it as a
+// module too names the same technology twice. that is the whole point of
+// BridgeFingerprints returning its id set, and nothing else enforces it.
+func TestSelectModulesDropsBridgedFromImplicitSelections(t *testing.T) {
+	bridgedID := "sif-test-bridged-fp"
+	otherID := "sif-test-plain-fp"
+	modules.Register(stubModule{id: bridgedID, tags: []string{"sif-test-tag"}})
+	modules.Register(stubModule{id: otherID, tags: []string{"sif-test-tag"}})
+
+	newApp := func(s *config.Settings) *App {
+		return &App{settings: s, bridgedFingerprints: map[string]bool{bridgedID: true}}
+	}
+
+	t.Run("-all-modules skips it", func(t *testing.T) {
+		got := newApp(&config.Settings{AllModules: true}).selectModules()
+		if has(got, bridgedID) {
+			t.Errorf("%s ran under -all-modules despite being bridged; it would be reported twice", bridgedID)
+		}
+		if !has(got, otherID) {
+			t.Errorf("%s was dropped too, want only the bridged id filtered (got %v)", otherID, ids(got))
+		}
+	})
+
+	t.Run("-tags skips it", func(t *testing.T) {
+		got := newApp(&config.Settings{ModuleTags: "sif-test-tag"}).selectModules()
+		if has(got, bridgedID) {
+			t.Errorf("%s ran under -tags despite being bridged", bridgedID)
+		}
+		if !has(got, otherID) {
+			t.Errorf("%s was dropped from the tag selection, got %v", otherID, ids(got))
+		}
+	})
+
+	// naming a module is a direct request, not an implicit sweep, so the
+	// filter must not silently swallow it.
+	t.Run("-modules still runs it", func(t *testing.T) {
+		got := newApp(&config.Settings{Modules: bridgedID}).selectModules()
+		if !has(got, bridgedID) {
+			t.Errorf("-modules %s selected nothing; an explicitly named module must run even when bridged", bridgedID)
+		}
+	})
+
+	// with no framework scan there is nothing to be covered by, so the
+	// selection must be untouched.
+	t.Run("nothing bridged is a passthrough", func(t *testing.T) {
+		app := &App{settings: &config.Settings{AllModules: true}}
+		got := app.selectModules()
+		if !has(got, bridgedID) || !has(got, otherID) {
+			t.Errorf("an empty bridged set must not filter anything, got %v", ids(got))
+		}
+	})
+}
+
+// the tag branch unions several ByTag results, which can name the same module
+// twice; the executor must not run it twice.
+func TestSelectModulesDedupesOverlappingTags(t *testing.T) {
+	id := "sif-test-two-tags"
+	modules.Register(stubModule{id: id, tags: []string{"sif-test-a", "sif-test-b"}})
+
+	app := &App{settings: &config.Settings{ModuleTags: "sif-test-a,sif-test-b"}}
+	got := app.selectModules()
+
+	n := 0
+	for _, m := range got {
+		if m.Info().ID == id {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("module matching both tags selected %d times, want 1", n)
+	}
+}


### PR DESCRIPTION
a fingerprint module and a framework detector can independently identify the same technology. this registers default-confidence, root-scoped fingerprint modules into the framework detector registry so framework detection covers yaml-defined technologies, and keeps the two engines from naming the same thing twice.

BridgeFingerprints is called from Run before scanAllTargets. it has to sit there: the per-target framework scan runs inside the -concurrency worker pool, so bridging any later would not reach it, and loading up front keeps the pool off the shared registry write path. the module set is now loaded once per run rather than once per target.

BridgeFingerprints returns the ids it bridged, and an implicit module run (-all-modules, -module-tags) skips them, so the technology is reported by the framework engine alone. naming a module with -modules is a direct request and still runs it. the two engines disagree on one boundary, the module engine fires at score >= confidence and the framework engine at score > threshold, so a bridged module sitting exactly at 0.5 is reported by neither in an implicit run. that is the residual bridgeableToFramework documents.

the bridged name is the module id and frameworks.Register clobbers by name, so a module called "WordPress" would have replaced the builtin detector. frameworks.RegisterIfAbsent does the check and the insert under one lock and the bridge refuses the name instead.

also marks the legacy custom-signature (signatures dir) path as deprecated in favour of fingerprint modules, without removing it.

stacked on #355 (shared sifpath/httpx helpers) and #356 (fingerprint module type), both open. this branch includes their commits so it builds standalone; rebasing after they merge should drop those as already-applied.
