### PR TITLE
ci: run go and functional-test on merge_group

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
   workflow_call:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
prereq for the merge queue. adds a `merge_group:` trigger to the go and functional-test workflows so the required checks (`build (1.25)`, `build-and-test`, `lint`) fire on the queue's synthetic branch.

without it a required merge queue would gate on checks that never run in the queue, hanging every PR. trigger-only, no logic change.