### PR TITLE
fix(modules): pass case-insensitive flag to tcp word matcher

### DIFF
--- a/internal/modules/tcp.go
+++ b/internal/modules/tcp.go
@@ -233,7 +233,7 @@ func checkTCPMatchers(matchers []Matcher, condition string, data string) bool {
 func checkTCPMatcher(m *Matcher, data string) bool {
 	switch m.Type {
 	case "word":
-		return checkWords(data, m.Words, m.Condition)
+		return checkWords(data, m.Words, m.Condition, m.CaseInsensitive)
 	case "regex":
 		return checkRegex(data, m.Regex, m.Condition)
 	case "size":


### PR DESCRIPTION
main is red: `internal/modules/tcp.go:236: not enough arguments in call to checkWords`.

#308 (tcp executor) called `checkWords/3`; #319 added the `caseInsensitive` param and updated the http path in executor.go but not the tcp path. both green alone, broken together once both merged.

one-line fix, mirrors executor.go:386 by passing `m.CaseInsensitive`. verified locally: `internal/modules` builds and tests pass.