### PR TITLE
fix(modules): read the chained-request body through the shared cap

### DIFF
--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -194,7 +194,7 @@ func executeHTTPChain(ctx context.Context, client *http.Client, target string, d
 			// a transport error breaks the chain; return whatever matched earlier.
 			return result, nil
 		}
-		respBody, err := io.ReadAll(io.LimitReader(resp.Body, MaxBodySize))
+		respBody, err := httpx.ReadCappedBody(resp)
 		resp.Body.Close()
 		if err != nil {
 			return result, nil


### PR DESCRIPTION
main does not build as of 2ce359a8:

```
internal/modules/executor.go:197:57: undefined: MaxBodySize
```

neither patch is wrong on its own. #317 added the request-chaining loop with `io.ReadAll(io.LimitReader(resp.Body, MaxBodySize))` against the const as it stood, then #355 moved the cap into `internal/httpx` and updated every reference that existed at the time. neither diff touches the other file, so both were green in isolation and only the merged tree breaks. I had a hand in the second half of that pair, so flagging it rather than leaving it to be found.

fix uses `httpx.ReadCappedBody`, which the same file already uses at line 423 and which `frameworks/detect.go` uses as well, so the chained read now goes through the same cap as every other body read.

verified `go build ./...` and `go test ./...` clean on top of current main.