### PR TITLE
feat(frameworks): enrich cve findings with reference urls

### DIFF
--- a/internal/finding/cve_regression_test.go
+++ b/internal/finding/cve_regression_test.go
@@ -1,0 +1,56 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package finding
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vmfunc/sif/internal/scan/frameworks"
+)
+
+// a cve-enriched framework result must still collapse to the frozen
+// "[severity] target module title" line - version, cves and references stay
+// out of Line() even once cve enrichment is populated, so downstream
+// notify/grep/awk consumers never see the line shape shift under them.
+func TestFlattenFramework_LineFrozenWithCVEEnrichment(t *testing.T) {
+	fw := &frameworks.FrameworkResult{
+		Name:        "Drupal",
+		Version:     "10",
+		Confidence:  0.9,
+		CVEs:        []string{"CVE-2023-44487 (high)"},
+		Suggestions: []string{"Update to Drupal 10.1.4 or later"},
+		RiskLevel:   "high",
+		References:  []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-44487"},
+	}
+
+	findings := Flatten(target, "framework", fw)
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(findings))
+	}
+
+	f := findings[0]
+	want := fmt.Sprintf("[%s] %s %s %s", f.Severity, target, "framework", "Drupal detected")
+	if got := f.Line(); got != want {
+		t.Errorf("Line() = %q, want %q", got, want)
+	}
+	if f.Severity != SeverityHigh {
+		t.Errorf("severity = %v, want %v (from RiskLevel=high)", f.Severity, SeverityHigh)
+	}
+	for _, leak := range []string{"CVE-2023-44487", "nvd.nist.gov"} {
+		if strings.Contains(f.Line(), leak) {
+			t.Errorf("Line() leaked enrichment detail %q: %q", leak, f.Line())
+		}
+	}
+}

--- a/internal/scan/builtin/frameworks_module.go
+++ b/internal/scan/builtin/frameworks_module.go
@@ -89,6 +89,11 @@ func (m *FrameworksModule) Execute(ctx context.Context, target string, opts modu
 		finding.Extracted["recommendations"] = strings.Join(frameworkResult.Suggestions, "; ")
 	}
 
+	// Add reference URLs
+	if len(frameworkResult.References) > 0 {
+		finding.Extracted["references"] = strings.Join(frameworkResult.References, ", ")
+	}
+
 	result.Findings = append(result.Findings, finding)
 
 	return result, nil

--- a/internal/scan/frameworks/cve.go
+++ b/internal/scan/frameworks/cve.go
@@ -20,6 +20,7 @@ type CVEEntry struct {
 	Severity         string // critical, high, medium, low
 	Description      string
 	Recommendations  []string
+	References       []string
 }
 
 // knownCVEs contains known vulnerabilities for popular frameworks.
@@ -33,6 +34,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "critical",
 			Description:      "Ignition debug mode RCE vulnerability",
 			Recommendations:  []string{"Update to Laravel 8.4.2 or later", "Disable debug mode in production"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-3129"},
 		},
 		{
 			CVE:              "CVE-2021-21263",
@@ -41,6 +43,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "high",
 			Description:      "SQL injection via request validation",
 			Recommendations:  []string{"Update to Laravel 8.5.0 or later", "Use parameterized queries"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-21263"},
 		},
 	},
 	"Django": {
@@ -51,6 +54,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "high",
 			Description:      "Potential ReDoS in EmailValidator and URLValidator",
 			Recommendations:  []string{"Update to Django 4.2.3 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-36053"},
 		},
 		{
 			CVE:              "CVE-2023-31047",
@@ -59,6 +63,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "medium",
 			Description:      "File upload validation bypass",
 			Recommendations:  []string{"Update to Django 4.1.9 or later", "Implement additional file validation"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-31047"},
 		},
 	},
 	"WordPress": {
@@ -69,6 +74,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "medium",
 			Description:      "Directory traversal vulnerability",
 			Recommendations:  []string{"Update to WordPress 6.2 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-2745"},
 		},
 	},
 	"Drupal": {
@@ -79,6 +85,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "high",
 			Description:      "HTTP/2 rapid reset attack (DoS)",
 			Recommendations:  []string{"Update to Drupal 10.1.4 or later", "Configure HTTP/2 rate limiting"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-44487"},
 		},
 	},
 	"Next.js": {
@@ -89,6 +96,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "medium",
 			Description:      "Server-side request forgery vulnerability",
 			Recommendations:  []string{"Update to Next.js 13.5.0 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-46298"},
 		},
 	},
 	"Angular": {
@@ -99,6 +107,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "medium",
 			Description:      "Regular expression denial of service",
 			Recommendations:  []string{"Update to Angular 15.2.0 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-26117"},
 		},
 	},
 	"Vue.js": {
@@ -109,6 +118,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "medium",
 			Description:      "XSS vulnerability in certain configurations",
 			Recommendations:  []string{"Update to Vue.js 2.7.16 or 3.x"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2024-5987"},
 		},
 	},
 	"Express.js": {
@@ -119,6 +129,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "medium",
 			Description:      "Open redirect vulnerability",
 			Recommendations:  []string{"Update to Express.js 4.19.2 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2024-29041"},
 		},
 	},
 	"Ruby on Rails": {
@@ -129,6 +140,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "high",
 			Description:      "ReDoS vulnerability in Action Dispatch",
 			Recommendations:  []string{"Update to Rails 7.0.4.1 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-22795"},
 		},
 	},
 	"Spring": {
@@ -139,6 +151,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "critical",
 			Description:      "Spring4Shell RCE vulnerability",
 			Recommendations:  []string{"Update to Spring 5.3.18 or later", "Disable class binding on user input"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2022-22965"},
 		},
 	},
 	"Spring Boot": {
@@ -149,6 +162,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "critical",
 			Description:      "RCE via Spring Cloud Function",
 			Recommendations:  []string{"Update to Spring Boot 2.6.6 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2022-22963"},
 		},
 	},
 	"ASP.NET": {
@@ -159,6 +173,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "high",
 			Description:      "Elevation of privilege vulnerability",
 			Recommendations:  []string{"Apply latest security patches", "Ensure proper request validation"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-36899"},
 		},
 	},
 	"Joomla": {
@@ -169,6 +184,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "critical",
 			Description:      "Improper access check allowing unauthorized access to webservice endpoints",
 			Recommendations:  []string{"Update to Joomla 4.2.8 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-23752"},
 		},
 	},
 	"Magento": {
@@ -179,6 +195,7 @@ var knownCVEs = map[string][]CVEEntry{
 			Severity:         "critical",
 			Description:      "Improper input validation leading to arbitrary code execution",
 			Recommendations:  []string{"Update to Magento 2.4.3-p1 or later"},
+			References:       []string{"https://nvd.nist.gov/vuln/detail/CVE-2022-24086"},
 		},
 	},
 }

--- a/internal/scan/frameworks/cve_internal_test.go
+++ b/internal/scan/frameworks/cve_internal_test.go
@@ -53,13 +53,13 @@ func TestResolveVersionFeedsCVELookup(t *testing.T) {
 	}
 
 	// ...and looking "unknown" up finds nothing, proving the old behavior missed it.
-	if cves, _ := getVulnerabilities("Laravel", "unknown"); len(cves) != 0 {
+	if cves, _, _ := getVulnerabilities("Laravel", "unknown"); len(cves) != 0 {
 		t.Fatalf("expected no CVEs for unknown version, got %v", cves)
 	}
 
 	// the reconciled version feeds the lookup and the CVE shows up.
 	version := resolveVersion("unknown", extracted)
-	cves, _ := getVulnerabilities("Laravel", version)
+	cves, _, _ := getVulnerabilities("Laravel", version)
 	if len(cves) == 0 {
 		t.Errorf("expected Laravel %s to surface a CVE, got none", version)
 	}
@@ -102,5 +102,24 @@ func TestVersionAffected(t *testing.T) {
 		if got := versionAffected(tt.version, tt.affected); got != tt.want {
 			t.Errorf("versionAffected(%q, %q) = %v, want %v", tt.version, tt.affected, got, tt.want)
 		}
+	}
+}
+
+// reference URLs are deterministic NVD detail links derived from the CVE ID,
+// carried alongside cves/recommendations for report-only enrichment.
+func TestGetVulnerabilitiesReferences(t *testing.T) {
+	_, _, references := getVulnerabilities("Drupal", "10")
+	if len(references) == 0 {
+		t.Fatal("expected at least one reference, got none")
+	}
+	want := "https://nvd.nist.gov/vuln/detail/CVE-2023-44487"
+	found := false
+	for _, ref := range references {
+		if ref == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected references to contain %q, got %v", want, references)
 	}
 }

--- a/internal/scan/frameworks/cve_internal_test.go
+++ b/internal/scan/frameworks/cve_internal_test.go
@@ -69,10 +69,10 @@ func TestResolveVersionFeedsCVELookup(t *testing.T) {
 // is "10"/"9". the cve lookup must still surface the matching CVE instead of
 // missing it because the affected entries are dotted.
 func TestGetVulnerabilitiesBareMajor(t *testing.T) {
-	if cves, _ := getVulnerabilities("Drupal", "10"); len(cves) == 0 {
+	if cves, _, _ := getVulnerabilities("Drupal", "10"); len(cves) == 0 {
 		t.Error("expected Drupal 10 to surface CVE-2023-44487, got none")
 	}
-	if cves, _ := getVulnerabilities("Drupal", "9"); len(cves) == 0 {
+	if cves, _, _ := getVulnerabilities("Drupal", "9"); len(cves) == 0 {
 		t.Error("expected Drupal 9 to surface CVE-2023-44487, got none")
 	}
 }

--- a/internal/scan/frameworks/cve_regression_test.go
+++ b/internal/scan/frameworks/cve_regression_test.go
@@ -1,0 +1,65 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package frameworks
+
+import "testing"
+
+// bare-major boundary matrix: a coarse detected major ("7") must cover its own
+// dotted sub-versions but never a version that merely shares the same leading
+// digits ("70.0", "17.0", "7000.0"). this is the off-by-one guard for the
+// bare-major fix in versionAffected - it pins the exact boundary, not just one
+// example of it.
+func TestVersionAffected_BareMajorBoundary(t *testing.T) {
+	tests := []struct {
+		version  string
+		affected string
+		want     bool
+	}{
+		{"7", "7.0", true},
+		{"7", "7.4", true},
+		{"7", "7.9", true},
+		{"7", "70.0", false},
+		{"7", "17.0", false},
+		{"7", "7000.0", false},
+		{"7", "6.9", false},
+		{"4.20", "4.2", false},
+		{"4.1", "4.10", false},
+		{"4.10", "4.1", false},
+	}
+
+	for _, tt := range tests {
+		if got := versionAffected(tt.version, tt.affected); got != tt.want {
+			t.Errorf("versionAffected(%q, %q) = %v, want %v", tt.version, tt.affected, got, tt.want)
+		}
+	}
+}
+
+// every CVE entry must carry at least one reference, and that reference must
+// be exactly the NVD detail link derived from the entry's own CVE ID - no
+// stale/typo'd/borrowed reference from a neighboring entry.
+func TestKnownCVEs_ReferencesMatchOwnCVEID(t *testing.T) {
+	for framework, entries := range knownCVEs {
+		for _, entry := range entries {
+			if len(entry.References) == 0 {
+				t.Errorf("%s %s: no references", framework, entry.CVE)
+				continue
+			}
+			want := "https://nvd.nist.gov/vuln/detail/" + entry.CVE
+			for _, ref := range entry.References {
+				if ref != want {
+					t.Errorf("%s %s: reference %q, want %q", framework, entry.CVE, ref, want)
+				}
+			}
+		}
+	}
+}

--- a/internal/scan/frameworks/detect.go
+++ b/internal/scan/frameworks/detect.go
@@ -200,10 +200,10 @@ func DetectFrameworks(url string, timeout time.Duration, logdir string) ([]*Fram
 func assembleResult(d detectionResult, bodyStr, url, logdir string, log *output.ModuleLogger) *FrameworkResult {
 	versionMatch := ExtractVersionOptimized(bodyStr, d.name)
 	version := resolveVersion(d.version, versionMatch.Version)
-	cves, suggestions := getVulnerabilities(d.name, version)
+	cves, suggestions, references := getVulnerabilities(d.name, version)
 
 	result := NewFrameworkResult(d.name, version, d.confidence, versionMatch.Confidence)
-	result.WithVulnerabilities(cves, suggestions)
+	result.WithVulnerabilities(cves, suggestions, references)
 
 	if logdir != "" {
 		logEntry := fmt.Sprintf("Detected framework: %s (version: %s, confidence: %.2f, version_confidence: %.2f)\n",
@@ -255,18 +255,19 @@ func resolveVersion(detectorVersion, extractedVersion string) string {
 	return unknownVersion
 }
 
-// getVulnerabilities returns CVEs and recommendations for a framework version.
-func getVulnerabilities(framework, version string) ([]string, []string) {
+// getVulnerabilities returns CVEs, recommendations and reference URLs for a
+// framework version.
+func getVulnerabilities(framework, version string) (cves, recommendations, references []string) {
 	entries, exists := knownCVEs[framework]
 	if !exists {
-		return nil, nil
+		return nil, nil, nil
 	}
 
-	var cves []string
-	var recommendations []string
 	seenRecs := make(map[string]bool)
+	seenRefs := make(map[string]bool)
 
-	for _, entry := range entries {
+	for i := range entries {
+		entry := &entries[i]
 		for _, affectedVer := range entry.AffectedVersions {
 			if versionAffected(version, affectedVer) {
 				cves = append(cves, fmt.Sprintf("%s (%s)", entry.CVE, entry.Severity))
@@ -276,12 +277,18 @@ func getVulnerabilities(framework, version string) ([]string, []string) {
 						seenRecs[rec] = true
 					}
 				}
+				for _, ref := range entry.References {
+					if !seenRefs[ref] {
+						references = append(references, ref)
+						seenRefs[ref] = true
+					}
+				}
 				break
 			}
 		}
 	}
 
-	return cves, recommendations
+	return cves, recommendations, references
 }
 
 // versionAffected reports whether version falls under an affected-version

--- a/internal/scan/frameworks/detect_test.go
+++ b/internal/scan/frameworks/detect_test.go
@@ -286,7 +286,7 @@ func TestDetectFramework_NoMatch(t *testing.T) {
 
 func TestFrameworkResult_Fields(t *testing.T) {
 	result := frameworks.NewFrameworkResult("Laravel", "9.0.0", 0.85, 0.9)
-	result.WithVulnerabilities([]string{"CVE-2021-3129"}, []string{"Update to latest version"})
+	result.WithVulnerabilities([]string{"CVE-2021-3129"}, []string{"Update to latest version"}, []string{"https://nvd.nist.gov/vuln/detail/CVE-2021-3129"})
 
 	if result.Name != "Laravel" {
 		t.Errorf("expected Name 'Laravel', got '%s'", result.Name)
@@ -305,6 +305,9 @@ func TestFrameworkResult_Fields(t *testing.T) {
 	}
 	if len(result.Suggestions) != 1 {
 		t.Errorf("expected 1 suggestion, got %d", len(result.Suggestions))
+	}
+	if len(result.References) != 1 {
+		t.Errorf("expected 1 reference, got %d", len(result.References))
 	}
 }
 
@@ -353,7 +356,7 @@ func TestDetermineRiskLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test via WithVulnerabilities which uses determineRiskLevel internally
 			result := frameworks.NewFrameworkResult("Test", "1.0", 0.5, 0.5)
-			result.WithVulnerabilities(tt.cves, nil)
+			result.WithVulnerabilities(tt.cves, nil, nil)
 			if result.RiskLevel != tt.expected {
 				t.Errorf("determineRiskLevel() = %q, want %q", result.RiskLevel, tt.expected)
 			}

--- a/internal/scan/frameworks/result.go
+++ b/internal/scan/frameworks/result.go
@@ -28,6 +28,7 @@ type FrameworkResult struct {
 	CVEs              []string `json:"cves,omitempty"`
 	Suggestions       []string `json:"suggestions,omitempty"`
 	RiskLevel         string   `json:"risk_level,omitempty"`
+	References        []string `json:"references,omitempty"`
 }
 
 // ResultType implements the ScanResult interface.
@@ -44,10 +45,11 @@ func NewFrameworkResult(name, version string, confidence, versionConfidence floa
 }
 
 // WithVulnerabilities adds CVE information to the result.
-func (r *FrameworkResult) WithVulnerabilities(cves, suggestions []string) *FrameworkResult {
+func (r *FrameworkResult) WithVulnerabilities(cves, suggestions, references []string) *FrameworkResult {
 	r.CVEs = cves
 	r.Suggestions = suggestions
 	r.RiskLevel = determineRiskLevel(cves)
+	r.References = references
 	return r
 }
 


### PR DESCRIPTION
a cve finding names the id and the severity but not where to read about it, so triage means pasting the id into a search engine. CVEEntry gains References, filled with the nvd detail url for its own id and surfaced on FrameworkResult.References and the builtin module's Extracted. report-only: finding.Finding and flattenFramework are untouched, so the normalized line sink does not change.