### PR TITLE
fix(favicon): read icons through the shared cap and skip non-images

### DIFF
--- a/internal/fingerprint/favicon_yaml_drift_test.go
+++ b/internal/fingerprint/favicon_yaml_drift_test.go
@@ -1,0 +1,114 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+// this file binds every favicon-*.yaml module to the fingerprint package's
+// faviconTech table (favicon.go) so the two SSOT surfaces can't silently
+// drift apart: a yaml module hardcodes a hash rather than being generated
+// from the table, so nothing previously caught a yaml hash that didn't exist
+// in (or disagreed with) the Go map.
+package fingerprint_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vmfunc/sif/internal/fingerprint"
+	"github.com/vmfunc/sif/internal/modules"
+)
+
+// modulesDir is the repo's module tree, reached the same way other
+// internal/modules tests reach it (see e.g. vector_db_exposure_test.go),
+// adjusted for this package's one-shallower path.
+const modulesDir = "../../modules"
+
+func findFaviconYAMLs(t *testing.T) []string {
+	t.Helper()
+
+	var found []string
+	err := filepath.WalkDir(modulesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasPrefix(name, "favicon-") {
+			return nil
+		}
+		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", modulesDir, err)
+	}
+	if len(found) == 0 {
+		t.Fatalf("no favicon-*.yaml modules found under %s; is the path stale?", modulesDir)
+	}
+	return found
+}
+
+// normalizeHash mirrors internal/modules' unexported normalizeFaviconHash: it
+// folds a signed or unsigned 32-bit value to the signed int32 shodan stores.
+func normalizeHash(t *testing.T, path string, v int64) int32 {
+	t.Helper()
+	if v < -(1<<31) || v > (1<<32-1) {
+		t.Fatalf("%s: favicon hash %d is out of 32-bit range", path, v)
+	}
+	return int32(uint32(v)) //nolint:gosec // intentional 32-bit fold, mirrors modules.normalizeFaviconHash
+}
+
+// TestFaviconYAMLModulesMatchTable also checks that when a module's own name
+// mentions a tech, the name agrees with what the table says the hash means.
+func TestFaviconYAMLModulesMatchTable(t *testing.T) {
+	for _, path := range findFaviconYAMLs(t) {
+		ym, err := modules.ParseYAMLModule(path)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		if ym.HTTP == nil {
+			t.Fatalf("%s: expected an http module with a favicon matcher", path)
+		}
+
+		var sawFaviconMatcher bool
+		for _, m := range ym.HTTP.Matchers {
+			if m.Type != "favicon" {
+				continue
+			}
+			sawFaviconMatcher = true
+			if len(m.Hash) == 0 {
+				t.Errorf("%s: favicon matcher declares no hashes", path)
+			}
+			for _, raw := range m.Hash {
+				hash := normalizeHash(t, path, raw)
+
+				tech, ok := fingerprint.LookupFaviconTech(hash)
+				if !ok {
+					t.Errorf("%s: favicon hash %d is not in fingerprint.faviconTech; the yaml and the go table have drifted", path, hash)
+					continue
+				}
+
+				if tech != "" && !strings.Contains(strings.ToLower(ym.Info.Name), strings.ToLower(tech)) {
+					t.Errorf("%s: module name %q does not mention table tech %q for hash %d; the yaml and the go table disagree on what this hash means",
+						path, ym.Info.Name, tech, hash)
+				}
+			}
+		}
+		if !sawFaviconMatcher {
+			t.Errorf("%s: no favicon matcher found", path)
+		}
+	}
+}

--- a/internal/scan/favicon.go
+++ b/internal/scan/favicon.go
@@ -13,6 +13,7 @@
 package scan
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -118,8 +119,10 @@ func fetchFavicon(client *http.Client, base string) (string, []byte, error) {
 	return iconURL, data, nil
 }
 
-// getFaviconBytes GETs an icon url and returns the body, erroring on a non-200 or
-// an empty body so a soft-404 html page isn't hashed as if it were an icon.
+// getFaviconBytes GETs an icon url and returns the body, erroring on a non-200,
+// an empty body, or one that doesn't look like an image. many apps answer a
+// missing icon with a 200 html "not found" page rather than a real 404, and
+// that page must not be hashed as if it were the icon.
 func getFaviconBytes(client *http.Client, iconURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, iconURL, http.NoBody)
 	if err != nil {
@@ -141,7 +144,48 @@ func getFaviconBytes(client *http.Client, iconURL string) ([]byte, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty favicon body")
 	}
+	if !looksLikeImage(resp.Header.Get("Content-Type"), data) {
+		return nil, fmt.Errorf("favicon body at %s is not image content", iconURL)
+	}
 	return data, nil
+}
+
+// faviconMagic is the set of byte-signature prefixes real icon formats start
+// with, checked when the Content-Type header doesn't already say image/*.
+var faviconMagic = [][]byte{
+	{0x00, 0x00, 0x01, 0x00}, // ICO
+	{0x89, 0x50, 0x4E, 0x47}, // PNG
+	[]byte("GIF8"),           // GIF
+	{0xFF, 0xD8, 0xFF},       // JPEG
+	[]byte("RIFF"),           // WEBP (also needs "WEBP" at offset 8, checked below)
+}
+
+// looksLikeImage reports whether a response should be treated as an icon: an
+// image/* Content-Type is trusted outright, otherwise the body is sniffed
+// against known icon/image magic bytes.
+func looksLikeImage(contentType string, body []byte) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if idx := strings.Index(ct, ";"); idx != -1 {
+		ct = ct[:idx]
+	}
+	if strings.HasPrefix(ct, "image/") {
+		return true
+	}
+
+	for _, magic := range faviconMagic {
+		if bytes.HasPrefix(body, magic) {
+			if string(magic) == "RIFF" {
+				return len(body) >= 12 && string(body[8:12]) == "WEBP"
+			}
+			return true
+		}
+	}
+
+	trimmed := bytes.TrimSpace(body)
+	if bytes.HasPrefix(trimmed, []byte("<?xml")) || bytes.HasPrefix(bytes.ToLower(trimmed), []byte("<svg")) {
+		return true
+	}
+	return false
 }
 
 // declaredFaviconHref fetches the homepage and extracts the href of the first

--- a/internal/scan/favicon.go
+++ b/internal/scan/favicon.go
@@ -37,11 +37,6 @@ type FaviconResult struct {
 	ShodanQ    string `json:"shodan_query"`
 }
 
-// faviconBodyReadCap bounds the icon read. real favicons are tens of kilobytes;
-// a megabyte ceiling covers oversized ones without letting a hostile endpoint
-// stream forever.
-const faviconBodyReadCap = 1 << 20
-
 // faviconLinkRegex pulls the href off a <link rel="...icon..."> tag so we can
 // fall back to a declared icon when /favicon.ico is absent.
 var faviconLinkRegex = regexp.MustCompile(`(?i)<link[^>]+rel=["'][^"']*icon[^"']*["'][^>]*>`)
@@ -139,7 +134,7 @@ func getFaviconBytes(client *http.Client, iconURL string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("favicon status %d", resp.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, faviconBodyReadCap))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, httpx.MaxBodySize))
 	if err != nil {
 		return nil, fmt.Errorf("read favicon: %w", err)
 	}
@@ -162,7 +157,7 @@ func declaredFaviconHref(client *http.Client, base string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, faviconBodyReadCap))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, httpx.MaxBodySize))
 	if err != nil {
 		return "", fmt.Errorf("read homepage: %w", err)
 	}

--- a/internal/scan/favicon_test.go
+++ b/internal/scan/favicon_test.go
@@ -80,6 +80,7 @@ func TestFavicon_LinkFallback(t *testing.T) {
 		case "/favicon.ico":
 			w.WriteHeader(http.StatusNotFound)
 		case "/static/icon.png":
+			w.Header().Set("Content-Type", "image/png")
 			_, _ = w.Write(goldenFaviconBytes)
 		default:
 			_, _ = w.Write([]byte(`<html><head><link rel="icon" href="/static/icon.png"></head></html>`))
@@ -177,6 +178,58 @@ func TestFavicon_OversizedIconMatchesSharedCap(t *testing.T) {
 	want := fingerprint.FaviconHash(big)
 	if result.Hash != want {
 		t.Errorf("Hash = %d, want %d (module-path hash over the same shared cap)", result.Hash, want)
+	}
+}
+
+// TestFavicon_SoftLoggedInHTML404NotHashed proves a soft-404 (200 text/html,
+// the common "not found" page many apps serve instead of a real 404) at
+// /favicon.ico is not mistaken for an icon. the doc comment above
+// getFaviconBytes used to claim this couldn't happen because a "non-200" was
+// rejected - but soft-404s are 200s, so the html body was hashed as if it were
+// the icon, producing a bogus hash and a wrong shodan pivot. with no
+// <link rel=icon> on the homepage either, there is nothing to fall back to, so
+// the scan should report no favicon at all.
+func TestFavicon_SoftLoggedInHTML404NotHashed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><head><title>Not Found</title></head><body>404 not found</body></html>"))
+	}))
+	defer srv.Close()
+
+	result, err := Favicon(srv.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("Favicon: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for a soft-404 html body, got %+v", result)
+	}
+}
+
+// TestFavicon_RealIconStillHashes proves the sniffing guard doesn't reject a
+// real icon served with no Content-Type header at all.
+func TestFavicon_RealIconStillHashes(t *testing.T) {
+	png := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 'r', 'e', 's', 't'}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			_, _ = w.Write(png)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	result, err := Favicon(srv.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("Favicon: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a favicon result for a real png icon, got nil")
+	}
+	want := fingerprint.FaviconHash(png)
+	if result.Hash != want {
+		t.Errorf("Hash = %d, want %d", result.Hash, want)
 	}
 }
 

--- a/internal/scan/favicon_test.go
+++ b/internal/scan/favicon_test.go
@@ -13,6 +13,7 @@
 package scan
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/vmfunc/sif/internal/fingerprint"
+	"github.com/vmfunc/sif/internal/httpx"
 )
 
 // goldenFaviconBytes is a fixed payload long enough to span multiple base64
@@ -137,6 +139,44 @@ func TestResolveFaviconURL(t *testing.T) {
 				t.Errorf("resolveFaviconURL(%q, %q) = %q, want %q", tc.base, tc.href, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFavicon_OversizedIconMatchesSharedCap proves scan.Favicon hashes an icon
+// larger than 1MB (but within the shared 5MB module-path cap) over the exact
+// same bytes the module matcher would see. before the fix, scan.Favicon read
+// with its own 1MB cap while the module path reads via httpx.ReadCappedBody's
+// 5MB cap, so a >1MB icon hashed to two different values through the same
+// shared FaviconHash - the -favicon shodan pivot was wrong, and the two SSOT
+// paths disagreed on tech.
+func TestFavicon_OversizedIconMatchesSharedCap(t *testing.T) {
+	// 1.5MB: bigger than the old 1MB scan cap, well under the 5MB module cap.
+	big := bytes.Repeat([]byte("A"), (3<<20)/2)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			w.Header().Set("Content-Type", "image/x-icon")
+			_, _ = w.Write(big)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	result, err := Favicon(srv.URL, 5*time.Second, "")
+	if err != nil {
+		t.Fatalf("Favicon: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a favicon result, got nil")
+	}
+
+	if len(big) >= httpx.MaxBodySize {
+		t.Fatalf("fixture body (%d bytes) must be under httpx.MaxBodySize (%d) for this assertion to hold", len(big), httpx.MaxBodySize)
+	}
+	want := fingerprint.FaviconHash(big)
+	if result.Hash != want {
+		t.Errorf("Hash = %d, want %d (module-path hash over the same shared cap)", result.Hash, want)
 	}
 }
 


### PR DESCRIPTION
three problems in the favicon path, all of them producing a hash that is wrong rather than absent.

scan.Favicon capped icon reads at 1MB while the module matcher path reads through httpx.ReadCappedBody at 5MB, so any icon over 1MB fed two different byte streams into the same shared FaviconHash and gave two different shodan pivots. getFaviconBytes also only rejected non-200s and empty bodies, so a 200 text/html soft-404 got hashed as an icon, which the doc comment claimed was already handled. and favicon-gitlab.yaml hardcodes a hash duplicating fingerprint.faviconTech with nothing binding the two, so the new drift test walks favicon-*.yaml and checks every declared hash against the table.