### PR TITLE
fix(modules): validate modules at load instead of at match time

### DIFF
--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -642,6 +642,24 @@ func checkRegex(content string, patterns []string, condition string) bool {
 	return true
 }
 
+// validateExtractors rejects a regex extractor whose pattern fails to
+// compile, at load rather than at match time: runExtractors (and its dns/tcp
+// counterparts) compile lazily and skip a bad pattern, which would otherwise
+// leave the extractor silently and permanently empty.
+func validateExtractors(extractors []Extractor) error {
+	for i := range extractors {
+		if extractors[i].Type != "regex" {
+			continue
+		}
+		for _, pattern := range extractors[i].Regex {
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf("regex extractor pattern %q: %w", pattern, err)
+			}
+		}
+	}
+	return nil
+}
+
 // runExtractors extracts data from the response.
 func runExtractors(extractors []Extractor, resp *http.Response, body string) map[string]string {
 	if len(extractors) == 0 {

--- a/internal/modules/favicon.go
+++ b/internal/modules/favicon.go
@@ -15,6 +15,7 @@ package modules
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 
 	"github.com/vmfunc/sif/internal/fingerprint"
@@ -78,16 +79,25 @@ func hasNonEmpty(vals []string) bool {
 }
 
 // validateMatchers fails favicon matchers that would silently never fire (no
-// hash, or one out of 32-bit range), an unknown matcher type and a malformed
-// range matcher at load rather than at match time. an empty word or regex list
-// matches every response under the default AND condition, so it is rejected
-// here too. dns and tcp narrow the allowlist further in their own validators.
+// hash, or one out of 32-bit range), an unknown matcher type, an unparseable
+// regex and a malformed range matcher at load rather than at match time. an
+// empty word or regex list matches every response under the default AND
+// condition, so it is rejected here too. dns and tcp narrow the allowlist
+// further in their own validators.
 func validateMatchers(matchers []Matcher) error {
 	for i := range matchers {
 		switch matchers[i].Type {
 		case "word", "regex", "status", "favicon", "size", "range":
 		default:
 			return fmt.Errorf("matcher type %q is not supported (use word, regex, status, favicon, size, or range)", matchers[i].Type)
+		}
+
+		if matchers[i].Type == "regex" {
+			for _, pattern := range matchers[i].Regex {
+				if _, err := regexp.Compile(pattern); err != nil {
+					return fmt.Errorf("regex matcher pattern %q: %w", pattern, err)
+				}
+			}
 		}
 
 		if matchers[i].Type == "favicon" {

--- a/internal/modules/favicon.go
+++ b/internal/modules/favicon.go
@@ -78,11 +78,18 @@ func hasNonEmpty(vals []string) bool {
 }
 
 // validateMatchers fails favicon matchers that would silently never fire (no
-// hash, or one out of 32-bit range) and malformed range matchers at load rather
-// than at match time. an empty word or regex list matches every response under
-// the default AND condition, so it is rejected here too, for every transport.
+// hash, or one out of 32-bit range), an unknown matcher type and a malformed
+// range matcher at load rather than at match time. an empty word or regex list
+// matches every response under the default AND condition, so it is rejected
+// here too. dns and tcp narrow the allowlist further in their own validators.
 func validateMatchers(matchers []Matcher) error {
 	for i := range matchers {
+		switch matchers[i].Type {
+		case "word", "regex", "status", "favicon", "size", "range":
+		default:
+			return fmt.Errorf("matcher type %q is not supported (use word, regex, status, favicon, size, or range)", matchers[i].Type)
+		}
+
 		if matchers[i].Type == "favicon" {
 			if len(matchers[i].Hash) == 0 {
 				return fmt.Errorf("favicon matcher requires at least one hash")

--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -209,6 +209,10 @@ func TestValidateMatchers(t *testing.T) {
 		{name: "regex with one real pattern allowed", matchers: []Matcher{{Type: "regex", Regex: []string{"real"}}}, wantErr: false},
 		{name: "unknown matcher type rejected", matchers: []Matcher{{Type: "words", Words: []string{"x"}}}, wantErr: true},
 		{name: "status matcher allowed", matchers: []Matcher{{Type: "status", Status: []int{200}}}, wantErr: false},
+		{name: "size matcher allowed", matchers: []Matcher{{Type: "size", Size: []int{100}}}, wantErr: false},
+		{name: "valid regex allowed", matchers: []Matcher{{Type: "regex", Regex: []string{`admin\d+`}}}, wantErr: false},
+		{name: "unclosed regex rejected", matchers: []Matcher{{Type: "regex", Regex: []string{"(unclosed"}}}, wantErr: true},
+		{name: "one bad pattern among good ones rejected", matchers: []Matcher{{Type: "regex", Regex: []string{`ok\d+`, "("}}}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -207,6 +207,8 @@ func TestValidateMatchers(t *testing.T) {
 		{name: "regex with nil patterns rejected", matchers: []Matcher{{Type: "regex", Regex: nil}}, wantErr: true},
 		{name: "regex with only empty pattern rejected", matchers: []Matcher{{Type: "regex", Regex: []string{""}}}, wantErr: true},
 		{name: "regex with one real pattern allowed", matchers: []Matcher{{Type: "regex", Regex: []string{"real"}}}, wantErr: false},
+		{name: "unknown matcher type rejected", matchers: []Matcher{{Type: "words", Words: []string{"x"}}}, wantErr: true},
+		{name: "status matcher allowed", matchers: []Matcher{{Type: "status", Status: []int{200}}}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/modules/loader.go
+++ b/internal/modules/loader.go
@@ -88,12 +88,10 @@ func resolveBuiltinDir() string {
 // development), then the freedesktop system data dirs so packaged installs
 // (modules under /usr/share/sif) are found too.
 //
-// The bare "modules" candidate resolves against whatever the working directory
-// happens to be at runtime, so it is only offered when the working directory is
-// a sif checkout (or when the binary carries no embedded set at all). That keeps
-// the development flow of editing modules/ and re-running the binary, without
-// letting a release binary run from some unrelated directory treat a modules/
-// folder it happens to find there as a trusted builtin source.
+// The bare "modules" candidate resolves against the working directory at
+// runtime, so it is only offered inside a sif checkout (or when the binary
+// carries no embedded set), keeping the edit-and-rerun flow without letting a
+// release binary trust a modules/ folder it happens to find.
 func builtinDirCandidates() []string {
 	candidates := make([]string, 0, 4)
 
@@ -149,14 +147,9 @@ func firstExistingDir(candidates []string) string {
 // LoadAll discovers and loads all modules from both built-in
 // and user directories.
 func (l *Loader) LoadAll() error {
-	// Load the modules embedded in the binary first, as the baseline builtin
-	// set, then layer the on-disk builtin dir over it. loadDir and loadFS
-	// both register by id, and Register replaces an existing id rather than
-	// duplicating it, so a disk module overrides only its own id; every other
-	// embedded module survives. This also covers the release-binary case
-	// (embedded, no builtinDir on disk) and the dev-tree case (both present,
-	// disk wins for whatever it ships) without an all-or-nothing choice
-	// between them.
+	// the embedded set is the baseline; the on-disk builtin dir layers over it.
+	// Register replaces by id rather than duplicating, so a disk module overrides
+	// only its own id and every other embedded module survives.
 	if l.embedded != nil {
 		if err := l.loadFS(l.embedded); err != nil {
 			log.Debugf("No embedded modules loaded: %v", err)
@@ -181,11 +174,15 @@ func (l *Loader) LoadAll() error {
 	return nil
 }
 
-// loadDir loads modules from a directory.
+// loadDir loads modules from a directory. a per-entry error is logged and
+// skipped rather than returned: filepath.Walk aborts the whole walk on the
+// first error a walkFn returns, silently dropping every module sorted after
+// the bad entry.
 func (l *Loader) loadDir(dir string, userDefined bool) error {
 	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			log.Debugf("Skipping %s: %v", path, err)
+			return nil
 		}
 
 		if info.IsDir() {

--- a/internal/modules/loader.go
+++ b/internal/modules/loader.go
@@ -17,6 +17,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/vmfunc/sif/internal/output"
@@ -28,6 +29,10 @@ import (
 // reach a parent directory, and modules/ sits above this package). it stays nil
 // in builds and tests that don't import that package, so the loader simply falls
 // back to the filesystem as before.
+// sifModulePath is this project's go module path, used to recognise a source
+// checkout as the working directory. see inSifCheckout.
+const sifModulePath = "github.com/vmfunc/sif"
+
 var builtinFS fs.FS
 
 // SetBuiltinFS registers the embedded module filesystem. see builtinFS.
@@ -70,6 +75,11 @@ func resolveBuiltinDir() string {
 	if dir := firstExistingDir(builtinDirCandidates()); dir != "" {
 		return dir
 	}
+	if builtinFS != nil {
+		// an embedded set is the baseline; do not point the disk walk at the
+		// working directory just to have a path.
+		return ""
+	}
 	return "modules"
 }
 
@@ -77,19 +87,45 @@ func resolveBuiltinDir() string {
 // most specific first: next to the executable, the working directory (for
 // development), then the freedesktop system data dirs so packaged installs
 // (modules under /usr/share/sif) are found too.
+//
+// The bare "modules" candidate resolves against whatever the working directory
+// happens to be at runtime, so it is only offered when the working directory is
+// a sif checkout (or when the binary carries no embedded set at all). That keeps
+// the development flow of editing modules/ and re-running the binary, without
+// letting a release binary run from some unrelated directory treat a modules/
+// folder it happens to find there as a trusted builtin source.
 func builtinDirCandidates() []string {
 	candidates := make([]string, 0, 4)
 
 	if execPath, err := os.Executable(); err == nil {
 		candidates = append(candidates, filepath.Join(filepath.Dir(execPath), "modules"))
 	}
-	candidates = append(candidates, "modules")
+	if builtinFS == nil || inSifCheckout() {
+		candidates = append(candidates, "modules")
+	}
 
 	for _, dir := range dataDirs() {
 		candidates = append(candidates, filepath.Join(dir, "sif", "modules"))
 	}
 
 	return candidates
+}
+
+// inSifCheckout reports whether the working directory is a sif source tree, by
+// reading the module path out of its go.mod. It is what separates "the developer
+// is running from the repo" from "the binary happens to be sitting next to some
+// other project's modules/ dir".
+func inSifCheckout() bool {
+	data, err := os.ReadFile("go.mod")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
+			return strings.TrimSpace(rest) == sifModulePath
+		}
+	}
+	return false
 }
 
 // dataDirs returns the freedesktop base data directories, honoring
@@ -113,19 +149,21 @@ func firstExistingDir(candidates []string) string {
 // LoadAll discovers and loads all modules from both built-in
 // and user directories.
 func (l *Loader) LoadAll() error {
-	// Load built-in modules first, preferring an on-disk modules/ dir (dev tree
-	// or a release that ships the folder alongside the binary).
-	before := l.loaded
-	if err := l.loadDir(l.builtinDir, false); err != nil {
-		log.Debugf("No built-in modules found: %v", err)
-	}
-
-	// nothing on disk: fall back to the modules embedded in the binary so a bare
-	// `go install`ed sif still ships its built-in modules.
-	if l.loaded == before && l.embedded != nil {
+	// Load the modules embedded in the binary first, as the baseline builtin
+	// set, then layer the on-disk builtin dir over it. loadDir and loadFS
+	// both register by id, and Register replaces an existing id rather than
+	// duplicating it, so a disk module overrides only its own id; every other
+	// embedded module survives. This also covers the release-binary case
+	// (embedded, no builtinDir on disk) and the dev-tree case (both present,
+	// disk wins for whatever it ships) without an all-or-nothing choice
+	// between them.
+	if l.embedded != nil {
 		if err := l.loadFS(l.embedded); err != nil {
 			log.Debugf("No embedded modules loaded: %v", err)
 		}
+	}
+	if err := l.loadDir(l.builtinDir, false); err != nil {
+		log.Debugf("No built-in modules found: %v", err)
 	}
 
 	// Load user modules (can override built-in)

--- a/internal/modules/loader_test.go
+++ b/internal/modules/loader_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 )
 
 // writeModule drops a yaml file into a temp dir and returns its path.
@@ -219,6 +220,63 @@ func TestLoaderLoadAll(t *testing.T) {
 	}
 }
 
+// TestLoaderMergesEmbeddedAndDiskByID confirms embedded and on-disk builtins
+// merge by module id, rather than the disk set winning outright whenever
+// anything on disk loads: every embedded-only id must still register, and a
+// disk module sharing an embedded id must override just that one entry.
+func TestLoaderMergesEmbeddedAndDiskByID(t *testing.T) {
+	Clear()
+	t.Cleanup(Clear)
+
+	embedded := fstest.MapFS{
+		"shared.yaml": &fstest.MapFile{Data: []byte("id: shared\ntype: http\ninfo:\n  description: embedded\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")},
+		"solo-a.yaml": &fstest.MapFile{Data: []byte("id: solo-a\ntype: http\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")},
+		"solo-b.yaml": &fstest.MapFile{Data: []byte("id: solo-b\ntype: http\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")},
+	}
+
+	dir := t.TempDir()
+	writeModule(t, dir, "shared.yaml", "id: shared\ntype: http\ninfo:\n  description: disk\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")
+
+	l := &Loader{builtinDir: dir, userDir: filepath.Join(dir, "nonexistent-user"), embedded: embedded}
+	if err := l.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	for _, id := range []string{"shared", "solo-a", "solo-b"} {
+		if _, ok := Get(id); !ok {
+			t.Errorf("%s not registered; embedded modules must survive a disk override elsewhere", id)
+		}
+	}
+
+	shared, ok := Get("shared")
+	if !ok {
+		t.Fatal("shared not registered")
+	}
+	if got := shared.Info().Description; got != "disk" {
+		t.Errorf("shared module description = %q, want %q (disk should override the embedded copy)", got, "disk")
+	}
+}
+
+// TestNewLoaderPrefersTrustedBuiltinOverCWD confirms that once an embedded
+// builtin set exists, NewLoader does not fall back to trusting a bare
+// "modules" directory relative to the current working directory: a release
+// binary run from an unrelated directory that happens to contain a modules/
+// folder must not have it silently treated as a builtin source.
+func TestNewLoaderPrefersTrustedBuiltinOverCWD(t *testing.T) {
+	origFS := builtinFS
+	t.Cleanup(func() { builtinFS = origFS })
+
+	SetBuiltinFS(fstest.MapFS{"x.yaml": &fstest.MapFile{Data: []byte("id: x\ntype: http\nhttp:\n  paths: [\"/\"]\n")}})
+
+	l, err := NewLoader()
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	if l.BuiltinDir() == "modules" {
+		t.Error("BuiltinDir() fell back to the bare CWD-relative \"modules\" path while an embedded builtin set was available")
+	}
+}
+
 func TestNewLoaderDirs(t *testing.T) {
 	l, err := NewLoader()
 	if err != nil {
@@ -379,5 +437,57 @@ func TestShippedModulesLoadClean(t *testing.T) {
 		if _, err := ParseYAMLModule(f); err != nil {
 			t.Errorf("%s: %v", f, err)
 		}
+	}
+}
+
+// TestBuiltinDirCandidatesCwdTrust pins both halves of the working-directory
+// rule: a sif checkout keeps the bare "modules" candidate, so editing modules/
+// and re-running the binary still works, while any other directory loses it
+// once an embedded set exists. Getting this wrong is silent either way - a
+// dropped candidate makes on-disk edits invisible, an extra one makes a
+// stranger's modules/ dir a trusted builtin source.
+func TestBuiltinDirCandidatesCwdTrust(t *testing.T) {
+	hasCwd := func(candidates []string) bool {
+		for _, c := range candidates {
+			if c == "modules" {
+				return true
+			}
+		}
+		return false
+	}
+
+	prev := builtinFS
+	t.Cleanup(func() { builtinFS = prev })
+	builtinFS = fstest.MapFS{}
+
+	t.Chdir(t.TempDir())
+	if hasCwd(builtinDirCandidates()) {
+		t.Error("a non-checkout working directory must not offer the bare modules candidate")
+	}
+
+	checkout := t.TempDir()
+	if err := os.WriteFile(filepath.Join(checkout, "go.mod"), []byte("module "+sifModulePath+"\n\ngo 1.25\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(checkout)
+	if !hasCwd(builtinDirCandidates()) {
+		t.Error("a sif checkout must keep the bare modules candidate so on-disk edits are seen")
+	}
+
+	other := t.TempDir()
+	if err := os.WriteFile(filepath.Join(other, "go.mod"), []byte("module example.com/other\n\ngo 1.25\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(other)
+	if hasCwd(builtinDirCandidates()) {
+		t.Error("another project's checkout must not offer the bare modules candidate")
+	}
+
+	// with no embedded set there is nothing to fall back on, so cwd is offered
+	// regardless of where the binary is run from.
+	builtinFS = nil
+	t.Chdir(t.TempDir())
+	if !hasCwd(builtinDirCandidates()) {
+		t.Error("without an embedded set the bare modules candidate must remain")
 	}
 }

--- a/internal/modules/loader_test.go
+++ b/internal/modules/loader_test.go
@@ -109,6 +109,26 @@ func TestParseYAMLModuleErrors(t *testing.T) {
 			name:    "type mismatch",
 			content: "id: bad-shape\ntype: http\nhttp: \"should-be-a-map\"\n",
 		},
+		{
+			// type http with no http: section at all: parses fine today and only
+			// fails at Execute, which never runs on a passive scan.
+			name:    "http type with no http section",
+			content: "id: no-http-section\ntype: http\n",
+		},
+		{
+			// a typo'd section name (htttp instead of http) leaves HTTP nil the
+			// same way, since yaml silently ignores unknown top-level keys.
+			name:    "typo'd http section",
+			content: "id: typo-http-section\ntype: http\nhtttp:\n  paths: [\"/\"]\n",
+		},
+		{
+			name:    "dns type with no dns section",
+			content: "id: no-dns-section\ntype: dns\n",
+		},
+		{
+			name:    "tcp type with no tcp section",
+			content: "id: no-tcp-section\ntype: tcp\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -118,6 +138,24 @@ func TestParseYAMLModuleErrors(t *testing.T) {
 				t.Fatalf("expected error for %s", tt.name)
 			}
 		})
+	}
+}
+
+// TestParseYAMLModuleStrictFields confirms a typo'd field inside a present
+// config block (as opposed to a missing/typo'd top-level section, covered by
+// TestParseYAMLModuleErrors) is rejected: strict/KnownFields decoding, not
+// just the block-presence check.
+func TestParseYAMLModuleStrictFields(t *testing.T) {
+	dir := t.TempDir()
+
+	typoField := writeModule(t, dir, "typo-field.yaml", "id: tf\ntype: http\nhttp:\n  methdo: GET\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")
+	if _, err := ParseYAMLModule(typoField); err == nil {
+		t.Fatal("typo'd field (methdo) inside http section accepted")
+	}
+
+	correctField := writeModule(t, dir, "correct-field.yaml", "id: cf\ntype: http\nhttp:\n  method: GET\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")
+	if _, err := ParseYAMLModule(correctField); err != nil {
+		t.Fatalf("valid field name rejected: %v", err)
 	}
 }
 

--- a/internal/modules/loader_test.go
+++ b/internal/modules/loader_test.go
@@ -220,6 +220,44 @@ func TestLoaderLoadAll(t *testing.T) {
 	}
 }
 
+// TestLoaderLoadDirSkipsUnreadableEntry proves one entry the walk cannot read
+// (a directory with its permissions stripped) does not abort the rest of the
+// walk: a module sorted after it must still load. filepath.Walk aborts
+// entirely on the first non-nil error a walkFn returns, and loadDir used to
+// just pass that error straight through.
+func TestLoaderLoadDirSkipsUnreadableEntry(t *testing.T) {
+	Clear()
+	t.Cleanup(Clear)
+
+	if os.Getuid() == 0 {
+		t.Skip("running as root: unreadable-permission trick does not apply")
+	}
+
+	dir := t.TempDir()
+	unreadable := filepath.Join(dir, "a-unreadable")
+	if err := os.Mkdir(unreadable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeModule(t, unreadable, "inner.yaml", "id: inner-mod\ntype: http\nhttp:\n  paths: [\"/\"]\n")
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+
+	// "zlast" sorts after "a-unreadable" so the walk must reach it only if it
+	// presses on past the unreadable directory instead of aborting there.
+	writeModule(t, dir, "zlast.yaml", "id: zlast-mod\ntype: http\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")
+
+	l := &Loader{builtinDir: dir, userDir: filepath.Join(dir, "nonexistent-user")}
+	if err := l.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	if _, ok := Get("zlast-mod"); !ok {
+		t.Error("zlast-mod not registered: an unreadable entry earlier in the walk dropped it")
+	}
+}
+
 // TestLoaderMergesEmbeddedAndDiskByID confirms embedded and on-disk builtins
 // merge by module id, rather than the disk set winning outright whenever
 // anything on disk loads: every embedded-only id must still register, and a

--- a/internal/modules/loader_test.go
+++ b/internal/modules/loader_test.go
@@ -136,6 +136,20 @@ func TestParseYAMLModuleErrors(t *testing.T) {
 			name:    "tcp type with no tcp section",
 			content: "id: no-tcp-section\ntype: tcp\n",
 		},
+		{
+			// a chained step's matchers go through the same validation as the
+			// single-request ones; an unknown type there must not load.
+			name:    "chained step unknown matcher type",
+			content: "id: bad-step-matcher\ntype: http\nhttp:\n  requests:\n    - path: \"/\"\n      matchers:\n        - type: stauts\n          status: [200]\n",
+		},
+		{
+			name:    "chained step uncompilable extractor",
+			content: "id: bad-step-extractor\ntype: http\nhttp:\n  requests:\n    - path: \"/\"\n      extractors:\n        - type: regex\n          name: token\n          regex: [\"(unclosed\"]\n",
+		},
+		{
+			name:    "top-level uncompilable extractor",
+			content: "id: bad-http-extractor\ntype: http\nhttp:\n  paths: [\"/\"]\n  extractors:\n    - type: regex\n      name: token\n      regex: [\"(unclosed\"]\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/modules/loader_test.go
+++ b/internal/modules/loader_test.go
@@ -123,6 +123,12 @@ func TestParseYAMLModuleErrors(t *testing.T) {
 			content: "id: typo-http-section\ntype: http\nhtttp:\n  paths: [\"/\"]\n",
 		},
 		{
+			// a typo'd severity must fail load rather than flow into
+			// Finding.Severity verbatim and never rank against a real one.
+			name:    "unknown severity",
+			content: "id: bad-severity\ntype: http\ninfo:\n  severity: CRTICAL\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n", //nolint:misspell // intentional typo fixture
+		},
+		{
 			name:    "dns type with no dns section",
 			content: "id: no-dns-section\ntype: dns\n",
 		},
@@ -157,6 +163,36 @@ func TestParseYAMLModuleStrictFields(t *testing.T) {
 	correctField := writeModule(t, dir, "correct-field.yaml", "id: cf\ntype: http\nhttp:\n  method: GET\n  paths: [\"/\"]\n  matchers:\n    - type: status\n      status: [200]\n")
 	if _, err := ParseYAMLModule(correctField); err != nil {
 		t.Fatalf("valid field name rejected: %v", err)
+	}
+}
+
+// TestValidateSeverity pins the known-set check: any casing of the five
+// documented levels passes, an empty severity is left alone (many modules
+// and test fixtures omit it; that is unrelated to catching a typo), and
+// anything else, including a near-miss typo, is rejected.
+func TestValidateSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity string
+		wantErr  bool
+	}{
+		{name: "info", severity: "info", wantErr: false},
+		{name: "low", severity: "low", wantErr: false},
+		{name: "medium", severity: "medium", wantErr: false},
+		{name: "high", severity: "high", wantErr: false},
+		{name: "critical", severity: "critical", wantErr: false},
+		{name: "uppercase", severity: "HIGH", wantErr: false},
+		{name: "mixed case", severity: "Medium", wantErr: false},
+		{name: "empty is left alone", severity: "", wantErr: false},
+		{name: "typo rejected", severity: "CRTICAL", wantErr: true}, //nolint:misspell // intentional typo fixture
+		{name: "unknown word rejected", severity: "urgent", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateSeverity(tt.severity); (err != nil) != tt.wantErr {
+				t.Errorf("validateSeverity(%q) err = %v, wantErr %v", tt.severity, err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/modules/loader_test.go
+++ b/internal/modules/loader_test.go
@@ -324,3 +324,22 @@ func TestResolveBuiltinDirFindsPackagedModules(t *testing.T) {
 		t.Errorf("resolveBuiltinDir = %q, want packaged %q", got, pkg)
 	}
 }
+
+// TestShippedModulesLoadClean parses every module shipped in the repo-root
+// modules/ tree so a new load-time guard is checked against real modules, not
+// just fixtures: it must reject genuinely bad modules without rejecting any
+// of these.
+func TestShippedModulesLoadClean(t *testing.T) {
+	files, err := filepath.Glob("../../modules/*/*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no shipped modules found; check the glob against modules/")
+	}
+	for _, f := range files {
+		if _, err := ParseYAMLModule(f); err != nil {
+			t.Errorf("%s: %v", f, err)
+		}
+	}
+}

--- a/internal/modules/tcp_test.go
+++ b/internal/modules/tcp_test.go
@@ -706,4 +706,30 @@ func TestParseTCPValidation(t *testing.T) {
 	if _, err := ParseYAMLModule(badCond); err == nil {
 		t.Fatal("invalid matchers-condition on tcp accepted")
 	}
+
+	badRegex := write("badregex.yaml", "id: brx\ntype: tcp\ntcp:\n  port: 6379\n  matchers:\n    - type: regex\n      regex: [\"(unclosed\"]\n")
+	if _, err := ParseYAMLModule(badRegex); err == nil {
+		t.Fatal("unclosed regex matcher on tcp accepted")
+	}
+
+	badExtractorRegex := write("badextractorregex.yaml", "id: ber\ntype: tcp\ntcp:\n  port: 6379\n  matchers:\n    - type: word\n      words: [x]\n  extractors:\n    - type: regex\n      name: y\n      regex: [\"(unclosed\"]\n")
+	if _, err := ParseYAMLModule(badExtractorRegex); err == nil {
+		t.Fatal("unclosed regex extractor on tcp accepted")
+	}
+}
+
+func TestExecuteTCPModuleCaseInsensitiveWord(t *testing.T) {
+	withFakeTCP(t, "+OK REDIS ready\r\n")
+	def := tcpDef(&TCPConfig{
+		Port:     6379,
+		Matchers: []Matcher{{Type: "word", Words: []string{"redis"}, CaseInsensitive: true}},
+	})
+
+	res, err := ExecuteTCPModule(context.Background(), "example.com", def, Options{})
+	if err != nil {
+		t.Fatalf("ExecuteTCPModule: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1 (case-insensitive word should hit mixed-case banner)", len(res.Findings))
+	}
 }

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -29,9 +29,34 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// knownSeverities are the severity levels documented in docs/modules.md.
+// severity is looked up case-insensitively against this set.
+var knownSeverities = map[string]bool{
+	"info":     true,
+	"low":      true,
+	"medium":   true,
+	"high":     true,
+	"critical": true,
+}
+
+// validateSeverity rejects a level outside the known set, so a misspelling
+// fails at load instead of flowing into Finding.Severity and never ranking
+// against a real one. an empty severity is left alone: plenty of modules omit
+// it deliberately.
+func validateSeverity(severity string) error {
+	if severity == "" {
+		return nil
+	}
+	if !knownSeverities[strings.ToLower(severity)] {
+		return fmt.Errorf("severity %q is not one of info, low, medium, high, critical", severity)
+	}
+	return nil
+}
 
 // YAMLModule represents a parsed YAML module file
 type YAMLModule struct {
@@ -129,6 +154,10 @@ func ParseYAMLModuleBytes(data []byte) (*YAMLModule, error) {
 
 	if ym.Type == "" {
 		return nil, fmt.Errorf("module missing required field: type")
+	}
+
+	if err := validateSeverity(ym.Info.Severity); err != nil {
+		return nil, fmt.Errorf("module %q: %w", ym.ID, err)
 	}
 
 	// a module's type must have its matching configuration block: this is what

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -25,6 +25,7 @@
 package modules
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -116,7 +117,9 @@ func ParseYAMLModule(path string) (*YAMLModule, error) {
 // so the loader can read modules from an embedded fs.FS as well as from disk.
 func ParseYAMLModuleBytes(data []byte) (*YAMLModule, error) {
 	var ym YAMLModule
-	if err := yaml.Unmarshal(data, &ym); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&ym); err != nil {
 		return nil, fmt.Errorf("parse yaml: %w", err)
 	}
 
@@ -126,6 +129,24 @@ func ParseYAMLModuleBytes(data []byte) (*YAMLModule, error) {
 
 	if ym.Type == "" {
 		return nil, fmt.Errorf("module missing required field: type")
+	}
+
+	// a module's type must have its matching configuration block: this is what
+	// keeps a missing or typo'd section (e.g. "htttp:") from parsing clean and
+	// only failing later, at Execute, which passive scans never reach.
+	switch ym.Type {
+	case TypeHTTP:
+		if ym.HTTP == nil {
+			return nil, fmt.Errorf("module %q: type %q requires an http configuration block", ym.ID, ym.Type)
+		}
+	case TypeDNS:
+		if ym.DNS == nil {
+			return nil, fmt.Errorf("module %q: type %q requires a dns configuration block", ym.ID, ym.Type)
+		}
+	case TypeTCP:
+		if ym.TCP == nil {
+			return nil, fmt.Errorf("module %q: type %q requires a tcp configuration block", ym.ID, ym.Type)
+		}
 	}
 
 	if ym.HTTP != nil {

--- a/internal/modules/yaml.go
+++ b/internal/modules/yaml.go
@@ -146,10 +146,19 @@ func ParseYAMLModuleBytes(data []byte) (*YAMLModule, error) {
 			if err := validateMatchers(step.Matchers); err != nil {
 				return nil, fmt.Errorf("module %q request %d: %w", ym.ID, i, err)
 			}
+			if err := validateExtractors(step.Extractors); err != nil {
+				return nil, fmt.Errorf("module %q request %d: %w", ym.ID, i, err)
+			}
+		}
+		if err := validateExtractors(ym.HTTP.Extractors); err != nil {
+			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
 		}
 	}
 	if ym.TCP != nil {
 		if err := validateTCP(ym.TCP); err != nil {
+			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
+		}
+		if err := validateExtractors(ym.TCP.Extractors); err != nil {
 			return nil, fmt.Errorf("module %q: %w", ym.ID, err)
 		}
 	}


### PR DESCRIPTION
stacked on #382, so only the commits above it are this pr's.

six more guards over the same theme, a module that loads clean and then quietly does nothing. unknown matcher types were let through where dns and tcp already reject them, regex compiled lazily at match time and swallowed the error, a type: http module with no http: block only failed at Execute, which a passive scan never reaches, and a typo'd severity ranked against nothing downstream.

the loader itself had two. loadDir aborted the whole walk on one unreadable entry, and LoadAll skipped the embedded set wholesale whenever anything loaded from an on-disk modules/ dir, so running sif from a directory that happens to contain one replaced every builtin. embedded is now the baseline that disk layers over by id.