### PR TITLE
feat(modules): add a dsl matcher over response variables

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -311,6 +311,48 @@ both 32-bit forms are accepted, so values from shodan or any favicon-hash tool
 drop in without conversion. pair it with a `status: 200` matcher so an error
 page served for `/favicon.ico` is not hashed. a finding fires when the body
 hashes to any listed value.
+### dsl matcher
+
+evaluate one or more boolean expressions against the response. the syntax and
+variable names are nuclei's, so an expression written for a nuclei template
+pastes in unchanged.
+
+```yaml
+matchers:
+  - type: dsl
+    dsl:
+      - "status_code == 200 && contains(body, 'admin')"
+      - "content_length > 1024"
+```
+
+the variables bound for every expression:
+
+| variable | type | value |
+|----------|------|-------|
+| `status_code` | int | response status code |
+| `body` | string | response body, after the 5 MB cap |
+| `content_length` | int | length of `body` in bytes |
+| `header` / `all_headers` | string | the response headers, one `Name: value` per line |
+| `duration` | float | round-trip time in seconds |
+| `host` | string | `host[:port]` of the request url |
+
+named extractor values are bound too, so an expression can test something an
+extractor pulled out of the same response; in a request chain it also sees the
+variables earlier steps extracted. an extractor whose name collides with a
+builtin shadows it, matching nuclei's mutation order.
+
+helper functions are an allowlist, not a blocklist: string inspection and
+transforms, `regex`/`regex_all`/`regex_any`, base64/hex/url/html encode and
+decode, `md5`/`sha1`/`sha256`/`mmh3`, and numeric conversion. anything else
+fails at load, so a dependency bump cannot quietly introduce a helper that reads
+files, makes its own requests, or allocates without bound. expressions are also
+capped at 4096 bytes.
+
+expressions are compiled and checked when the module loads, so a typo fails the
+module up front instead of silently never matching. at match time an expression
+that errors or yields a non-boolean counts as a miss. multiple expressions
+combine with AND by default, or with `condition: or`.
+
 ### combining matchers
 
 multiple matchers are combined with AND logic by default.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/charmbracelet/log v1.0.0
 	github.com/gocolly/colly/v2 v2.3.0
 	github.com/likexian/whois v1.15.7
+	github.com/projectdiscovery/dsl v0.8.20
 	github.com/projectdiscovery/goflags v0.1.76
+	github.com/projectdiscovery/govaluate v0.0.0-20260615100919-5ee2581bbf7e
 	github.com/projectdiscovery/nuclei/v3 v3.11.0
 	github.com/projectdiscovery/retryabledns v1.0.115
 	github.com/projectdiscovery/utils v0.11.1
@@ -272,7 +274,6 @@ require (
 	github.com/projectdiscovery/blackrock v0.0.1 // indirect
 	github.com/projectdiscovery/cdncheck v1.2.42 // indirect
 	github.com/projectdiscovery/clistats v0.1.4 // indirect
-	github.com/projectdiscovery/dsl v0.8.20 // indirect
 	github.com/projectdiscovery/fastdialer v0.5.11 // indirect
 	github.com/projectdiscovery/fasttemplate v0.0.2 // indirect
 	github.com/projectdiscovery/freeport v0.0.7 // indirect
@@ -282,7 +283,6 @@ require (
 	github.com/projectdiscovery/goja_nodejs v0.0.0-20260618132410-8519f75f703d // indirect
 	github.com/projectdiscovery/gologger v1.1.71 // indirect
 	github.com/projectdiscovery/gostruct v0.0.2 // indirect
-	github.com/projectdiscovery/govaluate v0.0.0-20260615100919-5ee2581bbf7e // indirect
 	github.com/projectdiscovery/gozero v0.1.1-0.20260530071156-fa1dad563d76 // indirect
 	github.com/projectdiscovery/hmap v0.0.101 // indirect
 	github.com/projectdiscovery/httpx v1.9.0 // indirect

--- a/internal/modules/dsl.go
+++ b/internal/modules/dsl.go
@@ -14,6 +14,7 @@ package modules
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -104,4 +105,65 @@ func dslCompile(expr string) (*govaluate.EvaluableExpression, error) {
 	}
 	actual, _ := dslCache.LoadOrStore(expr, compiled)
 	return actual.(*govaluate.EvaluableExpression), nil
+}
+
+// dslVars builds the variable environment a dsl expression evaluates against,
+// using nuclei's lowercase names so nuclei dsl expressions paste in unchanged.
+// Named extractor values overlay the builtins (matching nuclei's mutation
+// order), so an extractor may reference, and on a name clash shadow, a builtin.
+func dslVars(mc *MatchContext) map[string]interface{} {
+	vars := map[string]interface{}{
+		"status_code":    statusCodeOf(mc.Resp),
+		"body":           mc.Body,
+		"content_length": len(mc.Body),
+		"all_headers":    getPart("header", mc.Resp, mc.Body),
+		"header":         getPart("header", mc.Resp, mc.Body),
+		"duration":       mc.Duration.Seconds(),
+		"host":           mc.URL,
+	}
+	for k, v := range mc.Extracted {
+		vars[k] = v
+	}
+	return vars
+}
+
+func statusCodeOf(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}
+
+// evalDSL folds a dsl matcher's expressions under its condition (default AND).
+// An expression that errors at eval, or yields a non-bool, counts as false
+// (fail-closed), matching the engine's swallow-at-match-time invariant.
+func evalDSL(m *Matcher, mc *MatchContext) bool {
+	if len(m.DSL) == 0 {
+		return false
+	}
+	vars := dslVars(mc)
+	or := strings.EqualFold(m.Condition, "or")
+	for _, expr := range m.DSL {
+		matched := evalOneDSL(expr, vars)
+		if or && matched {
+			return true
+		}
+		if !or && !matched {
+			return false
+		}
+	}
+	return !or
+}
+
+func evalOneDSL(expr string, vars map[string]interface{}) bool {
+	compiled, err := dslCompile(expr)
+	if err != nil {
+		return false // unreachable after load validation; fail closed anyway
+	}
+	result, err := compiled.Evaluate(vars)
+	if err != nil {
+		return false // unbound var / type mismatch -> miss
+	}
+	b, ok := result.(bool)
+	return ok && b
 }

--- a/internal/modules/dsl.go
+++ b/internal/modules/dsl.go
@@ -1,0 +1,107 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/projectdiscovery/dsl"
+	"github.com/projectdiscovery/govaluate"
+)
+
+// maxDSLExprLen bounds a single dsl expression. govaluate's Evaluate takes no
+// context and cannot be interrupted mid-helper, so capping the input is the
+// reliable defense against a pathological expression.
+const maxDSLExprLen = 4096
+
+// allowedDSLHelpers is the set of helper functions a dsl expression may call,
+// keyed by the underscore-stripped name so both alias forms (to_lower and
+// tolower) resolve. It is an allowlist so a future projectdiscovery/dsl bump
+// cannot silently reintroduce a side-effecting helper (llm_prompt, public_ip,
+// wait_for, the gadget generators) or an unbounded-allocation one (repeat, the
+// rand_* and faker families): anything unnamed here fails to compile.
+var allowedDSLHelpers = func() map[string]bool {
+	names := []string{
+		// string inspection / comparison
+		"contains", "contains_all", "contains_any", "starts_with", "ends_with",
+		"line_starts_with", "line_ends_with", "equals_any", "len", "index",
+		// string transforms
+		"to_lower", "to_upper", "trim", "trim_left", "trim_right", "trim_space",
+		"trim_prefix", "trim_suffix", "split", "join", "replace", "replace_regex",
+		"concat", "reverse",
+		// regex (RE2, linear-time)
+		"regex", "regex_all", "regex_any",
+		// encode / decode
+		"base64", "base64_decode", "hex_encode", "hex_decode",
+		"url_encode", "url_decode", "html_escape", "html_unescape",
+		// hashing / fingerprint
+		"md5", "sha1", "sha256", "mmh3",
+		// numeric / conversion
+		"to_number", "to_string",
+	}
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[stripUnderscore(n)] = true
+	}
+	return m
+}()
+
+func stripUnderscore(s string) string { return strings.ReplaceAll(s, "_", "") }
+
+// dslHelpers is the curated govaluate function map: every entry of
+// dsl.HelperFunctions() whose (underscore-stripped) name is allowlisted.
+var dslHelpers = func() map[string]govaluate.ExpressionFunction {
+	all := dsl.HelperFunctions()
+	out := make(map[string]govaluate.ExpressionFunction, len(all))
+	for name, fn := range all {
+		if allowedDSLHelpers[stripUnderscore(name)] {
+			out[name] = fn
+		}
+	}
+	return out
+}()
+
+// dslCache memoizes compiled expressions by source string. A compiled
+// *EvaluableExpression is safe to Evaluate concurrently (value receiver, pooled
+// scratch state), so sharing one across goroutines is fine.
+var dslCache sync.Map // string -> *govaluate.EvaluableExpression
+
+// hasNonEmptyDSL reports whether exprs holds at least one non-empty expression.
+func hasNonEmptyDSL(exprs []string) bool {
+	for _, e := range exprs {
+		if strings.TrimSpace(e) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// dslCompile compiles expr against the curated helpers, caching the result, so
+// an over-length expression, a syntax error or a non-allowlisted function is
+// rejected at module load rather than silently missing at match time.
+func dslCompile(expr string) (*govaluate.EvaluableExpression, error) {
+	if len(expr) > maxDSLExprLen {
+		return nil, fmt.Errorf("dsl expression exceeds %d bytes", maxDSLExprLen)
+	}
+	if cached, ok := dslCache.Load(expr); ok {
+		return cached.(*govaluate.EvaluableExpression), nil
+	}
+	compiled, err := govaluate.NewEvaluableExpressionWithFunctions(expr, dslHelpers)
+	if err != nil {
+		return nil, fmt.Errorf("dsl expression %q: %w", expr, err)
+	}
+	actual, _ := dslCache.LoadOrStore(expr, compiled)
+	return actual.(*govaluate.EvaluableExpression), nil
+}

--- a/internal/modules/dsl.go
+++ b/internal/modules/dsl.go
@@ -15,6 +15,7 @@ package modules
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -112,19 +113,31 @@ func dslCompile(expr string) (*govaluate.EvaluableExpression, error) {
 // Named extractor values overlay the builtins (matching nuclei's mutation
 // order), so an extractor may reference, and on a name clash shadow, a builtin.
 func dslVars(mc *MatchContext) map[string]interface{} {
+	headers := getPart("header", mc.Resp, mc.Body)
 	vars := map[string]interface{}{
 		"status_code":    statusCodeOf(mc.Resp),
 		"body":           mc.Body,
 		"content_length": len(mc.Body),
-		"all_headers":    getPart("header", mc.Resp, mc.Body),
-		"header":         getPart("header", mc.Resp, mc.Body),
+		"all_headers":    headers,
+		"header":         headers,
 		"duration":       mc.Duration.Seconds(),
-		"host":           mc.URL,
+		"host":           hostOf(mc.URL),
 	}
 	for k, v := range mc.Extracted {
 		vars[k] = v
 	}
 	return vars
+}
+
+// hostOf returns the host[:port] of a request URL, matching nuclei's `host`
+// variable so a pasted nuclei expression (host == "example.com") behaves as
+// expected. On an unparseable URL it falls back to the raw string rather than
+// binding an empty host.
+func hostOf(rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return rawURL
 }
 
 func statusCodeOf(resp *http.Response) int {

--- a/internal/modules/dsl_test.go
+++ b/internal/modules/dsl_test.go
@@ -109,6 +109,22 @@ func TestCheckMatcherDSLNegative(t *testing.T) {
 	}
 }
 
+func TestCheckMatcherDSLHost(t *testing.T) {
+	// host must bind the hostname (nuclei parity), not the full requested URL,
+	// so a pasted `host == "..."` expression behaves as a nuclei user expects.
+	mc := &MatchContext{
+		Resp: fakeResponse(t, 200, nil),
+		Body: "x",
+		URL:  "http://example.com/admin/panel",
+	}
+	if m := (&Matcher{Type: "dsl", DSL: []string{`host == "example.com"`}}); !checkMatcher(m, mc) {
+		t.Error(`host should bind the hostname "example.com", got a miss`)
+	}
+	if m := (&Matcher{Type: "dsl", DSL: []string{`contains(host, "/admin")`}}); checkMatcher(m, mc) {
+		t.Error("host must not contain the URL path")
+	}
+}
+
 func TestCheckMatcherDSLExtractorVar(t *testing.T) {
 	mc := &MatchContext{
 		Resp:      fakeResponse(t, 200, nil),

--- a/internal/modules/dsl_test.go
+++ b/internal/modules/dsl_test.go
@@ -1,0 +1,42 @@
+/*
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+:                                                                               :
+:   █▀ █ █▀▀   ·   Blazing-fast pentesting suite                                :
+:   ▄█ █ █▀    ·   BSD 3-Clause License                                         :
+:                                                                               :
+:   (c) 2022-2026 vmfunc, xyzeva,                                               :
+:                 lunchcat alumni & contributors                                :
+:                                                                               :
+·━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━·
+*/
+
+package modules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDSLCompile(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{"valid comparison", "status_code == 200", false},
+		{"valid helper", `contains(body, "admin")`, false},
+		{"bad syntax", "status_code ==", true},
+		{"non-allowlisted side-effect helper", "wait_for(1)", true},
+		{"non-allowlisted network helper", "public_ip()", true},
+		{"non-allowlisted alloc helper", `repeat("A", 1000000)`, true},
+		{"over-length expression", strings.Repeat("a", maxDSLExprLen+1), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dslCompile(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("dslCompile(%q) err = %v, wantErr %v", tt.expr, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/modules/dsl_test.go
+++ b/internal/modules/dsl_test.go
@@ -150,3 +150,25 @@ func TestCheckMatcherDSLEvalErrorMisses(t *testing.T) {
 		t.Error("or with a valid true expr after a bad-eval expr should match")
 	}
 }
+
+func TestCheckMatcherDSLCompileErrorMisses(t *testing.T) {
+	mc := &MatchContext{Resp: fakeResponse(t, 200, nil), Body: "x"}
+	// load-time validation rejects this, but a matcher built in code bypasses
+	// that path, so evaluation itself must fail closed.
+	m := &Matcher{Type: "dsl", DSL: []string{`status_code ==`}}
+	if checkMatcher(m, mc) {
+		t.Error("an uncompilable expression must miss, not match")
+	}
+}
+
+func TestCheckMatcherDSLNilResponse(t *testing.T) {
+	// a matcher can run without a response; the variable environment must bind
+	// zero values instead of dereferencing nil.
+	mc := &MatchContext{Body: ""}
+	if m := (&Matcher{Type: "dsl", DSL: []string{"status_code == 0"}}); !checkMatcher(m, mc) {
+		t.Error("status_code should bind 0 with no response")
+	}
+	if m := (&Matcher{Type: "dsl", DSL: []string{`all_headers == ""`}}); !checkMatcher(m, mc) {
+		t.Error("all_headers should bind empty with no response")
+	}
+}

--- a/internal/modules/dsl_test.go
+++ b/internal/modules/dsl_test.go
@@ -13,6 +13,7 @@
 package modules
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -38,5 +39,98 @@ func TestDSLCompile(t *testing.T) {
 				t.Fatalf("dslCompile(%q) err = %v, wantErr %v", tt.expr, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestCheckMatcherDSL(t *testing.T) {
+	const body = "welcome admin dashboard"
+	resp := fakeResponse(t, 200, http.Header{"X-Powered-By": []string{"nginx"}})
+	mc := &MatchContext{Resp: resp, Body: body}
+
+	tests := []struct {
+		name   string
+		dsl    []string
+		expect bool
+	}{
+		{"status_code true", []string{"status_code == 200"}, true},
+		{"status_code false", []string{"status_code == 500"}, false},
+		{"body contains", []string{`contains(body, "admin")`}, true},
+		{"content_length", []string{"content_length > 5"}, true},
+		{"all_headers", []string{`contains(to_lower(all_headers), "nginx")`}, true},
+		{"header alias", []string{`contains(to_lower(header), "nginx")`}, true},
+		{"unbound var misses", []string{"nonexistent_var == 1"}, false},
+		{"non-bool result misses", []string{"len(body)"}, false},
+		{"empty list false", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Matcher{Type: "dsl", DSL: tt.dsl}
+			if got := checkMatcher(m, mc); got != tt.expect {
+				t.Errorf("dsl %v = %v, want %v", tt.dsl, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestCheckMatcherDSLCondition(t *testing.T) {
+	const body = "hello world"
+	mc := &MatchContext{Resp: fakeResponse(t, 200, nil), Body: body}
+	trueExpr := "status_code == 200"
+	falseExpr := "status_code == 500"
+
+	tests := []struct {
+		name      string
+		condition string
+		dsl       []string
+		expect    bool
+	}{
+		{"and both true", "and", []string{trueExpr, `contains(body, "hello")`}, true},
+		{"and one false", "and", []string{trueExpr, falseExpr}, false},
+		{"empty defaults to and", "", []string{trueExpr, falseExpr}, false},
+		{"or one true", "or", []string{falseExpr, trueExpr}, true},
+		{"or none true", "or", []string{falseExpr, `contains(body, "absent")`}, false},
+		{"AND case-insensitive", "AND", []string{trueExpr, falseExpr}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Matcher{Type: "dsl", Condition: tt.condition, DSL: tt.dsl}
+			if got := checkMatcher(m, mc); got != tt.expect {
+				t.Errorf("dsl cond %q %v = %v, want %v", tt.condition, tt.dsl, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestCheckMatcherDSLNegative(t *testing.T) {
+	mc := &MatchContext{Resp: fakeResponse(t, 200, nil), Body: "x"}
+	ms := []Matcher{{Type: "dsl", DSL: []string{"status_code == 200"}, Negative: true}}
+	if checkMatchers(ms, "", mc) {
+		t.Error("negative dsl matcher on a matching response should yield false")
+	}
+}
+
+func TestCheckMatcherDSLExtractorVar(t *testing.T) {
+	mc := &MatchContext{
+		Resp:      fakeResponse(t, 200, nil),
+		Body:      "x",
+		Extracted: map[string]string{"version": "1.2.3"},
+	}
+	m := &Matcher{Type: "dsl", DSL: []string{`version == "1.2.3"`}}
+	if !checkMatcher(m, mc) {
+		t.Error("dsl matcher should see the named extractor variable")
+	}
+}
+
+func TestCheckMatcherDSLEvalErrorMisses(t *testing.T) {
+	mc := &MatchContext{Resp: fakeResponse(t, 200, nil), Body: "x"}
+	// compiles fine, errors at eval (string vs number comparison)
+	m := &Matcher{Type: "dsl", DSL: []string{`body > 5`}}
+	if checkMatcher(m, mc) {
+		t.Error("an expression that errors at eval must miss, not match")
+	}
+	// under or, a bad-eval expr followed by a valid true expr still matches
+	m2 := &Matcher{Type: "dsl", Condition: "or", DSL: []string{`body > 5`, "status_code == 200"}}
+	if !checkMatcher(m2, mc) {
+		t.Error("or with a valid true expr after a bad-eval expr should match")
 	}
 }

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -564,30 +564,34 @@ func inRange(v int, lo, hi *int) bool {
 func getPart(part string, resp *http.Response, body string) string {
 	switch part {
 	case "header", "headers":
-		var sb strings.Builder
-		for k, v := range resp.Header {
-			sb.WriteString(k)
-			sb.WriteString(": ")
-			sb.WriteString(strings.Join(v, ", "))
-			sb.WriteString("\n")
-		}
-		return sb.String()
+		return headersOf(resp)
 	case "body":
 		return body
 	case "all", "":
 		var sb strings.Builder
-		for k, v := range resp.Header {
-			sb.WriteString(k)
-			sb.WriteString(": ")
-			sb.WriteString(strings.Join(v, ", "))
-			sb.WriteString("\n")
-		}
+		sb.WriteString(headersOf(resp))
 		sb.WriteString("\n")
 		sb.WriteString(body)
 		return sb.String()
 	default:
 		return body
 	}
+}
+
+// headersOf tolerates a nil resp (a matcher may run without one) rather than
+// dereferencing it.
+func headersOf(resp *http.Response) string {
+	if resp == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for k, v := range resp.Header {
+		sb.WriteString(k)
+		sb.WriteString(": ")
+		sb.WriteString(strings.Join(v, ", "))
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }
 
 // checkWords checks if any/all words are found.

--- a/internal/modules/executor.go
+++ b/internal/modules/executor.go
@@ -541,6 +541,9 @@ func checkMatcher(m *Matcher, mc *MatchContext) bool {
 			return false
 		}
 
+	case "dsl":
+		return evalDSL(m, mc)
+
 	default:
 		return false
 	}

--- a/internal/modules/executor_test.go
+++ b/internal/modules/executor_test.go
@@ -363,6 +363,40 @@ func TestExecuteHTTPModuleWordlist(t *testing.T) {
 	}
 }
 
+// drives the full executor with a dsl matcher: fetch a live response, evaluate
+// the expression against its bound variables, report exactly one finding.
+func TestExecuteHTTPModuleDSL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "nginx")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("welcome admin dashboard"))
+	}))
+	defer srv.Close()
+
+	def := &YAMLModule{
+		ID:   "dsl-e2e",
+		Type: TypeHTTP,
+		Info: YAMLModuleInfo{Severity: "info"},
+		HTTP: &HTTPConfig{
+			Method: "GET",
+			Paths:  []string{"{{BaseURL}}/"},
+			Matchers: []Matcher{{
+				Type: "dsl",
+				DSL:  []string{`status_code == 200 && contains(body, "admin")`},
+			}},
+		},
+	}
+	opts := Options{Timeout: testTimeout, Client: httpx.Client(testTimeout)}
+
+	result, err := ExecuteHTTPModule(context.Background(), srv.URL, def, opts)
+	if err != nil {
+		t.Fatalf("ExecuteHTTPModule: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected exactly 1 dsl finding, got %d", len(result.Findings))
+	}
+}
+
 func TestTruncateEvidence(t *testing.T) {
 	short := "short evidence"
 	if got := truncateEvidence(short); got != short {

--- a/internal/modules/favicon.go
+++ b/internal/modules/favicon.go
@@ -78,9 +78,10 @@ func hasNonEmpty(vals []string) bool {
 }
 
 // validateMatchers fails favicon matchers that would silently never fire (no
-// hash, or one out of 32-bit range) and malformed range matchers at load rather
-// than at match time. an empty word or regex list matches every response under
-// the default AND condition, so it is rejected here too, for every transport.
+// hash, or one out of 32-bit range), malformed range matchers, and dsl matchers
+// that are empty or do not compile, at load rather than at match time. an empty
+// word or regex list matches every response under the default AND condition, so
+// it is rejected here too, for every transport.
 func validateMatchers(matchers []Matcher) error {
 	for i := range matchers {
 		if matchers[i].Type == "favicon" {
@@ -100,6 +101,17 @@ func validateMatchers(matchers []Matcher) error {
 
 		if matchers[i].Type == "regex" && !hasNonEmpty(matchers[i].Regex) {
 			return fmt.Errorf("regex matcher requires at least one non-empty pattern")
+		}
+
+		if matchers[i].Type == "dsl" {
+			if !hasNonEmptyDSL(matchers[i].DSL) {
+				return fmt.Errorf("dsl matcher requires at least one non-empty expression")
+			}
+			for _, expr := range matchers[i].DSL {
+				if _, err := dslCompile(expr); err != nil {
+					return fmt.Errorf("dsl matcher: %w", err)
+				}
+			}
 		}
 
 		if matchers[i].Type == "range" {

--- a/internal/modules/favicon_test.go
+++ b/internal/modules/favicon_test.go
@@ -207,6 +207,12 @@ func TestValidateMatchers(t *testing.T) {
 		{name: "regex with nil patterns rejected", matchers: []Matcher{{Type: "regex", Regex: nil}}, wantErr: true},
 		{name: "regex with only empty pattern rejected", matchers: []Matcher{{Type: "regex", Regex: []string{""}}}, wantErr: true},
 		{name: "regex with one real pattern allowed", matchers: []Matcher{{Type: "regex", Regex: []string{"real"}}}, wantErr: false},
+		{name: "valid dsl allowed", matchers: []Matcher{{Type: "dsl", DSL: []string{"status_code == 200"}}}, wantErr: false},
+		{name: "bad dsl syntax rejected", matchers: []Matcher{{Type: "dsl", DSL: []string{"status_code =="}}}, wantErr: true},
+		{name: "one bad dsl among good rejected", matchers: []Matcher{{Type: "dsl", DSL: []string{"status_code == 200", "((("}}}, wantErr: true},
+		{name: "non-allowlisted dsl helper rejected", matchers: []Matcher{{Type: "dsl", DSL: []string{"wait_for(1)"}}}, wantErr: true},
+		{name: "empty dsl rejected", matchers: []Matcher{{Type: "dsl"}}, wantErr: true},
+		{name: "only-empty dsl expression rejected", matchers: []Matcher{{Type: "dsl", DSL: []string{""}}}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/modules/matchers_test.go
+++ b/internal/modules/matchers_test.go
@@ -250,6 +250,22 @@ func TestCheckRegex(t *testing.T) {
 	}
 }
 
+// a dsl matcher is compiled at load, so an uncompilable expression must fail the
+// whole module rather than silently never matching at scan time.
+func TestParseYAMLModuleDSLMatcher(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string { return writeModule(t, dir, name, body) }
+
+	badDSL := write("bad-matcher-dsl.yaml", "id: bmd\ntype: http\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: dsl\n      dsl: [\"status_code ==\"]\n")
+	if _, err := ParseYAMLModule(badDSL); err == nil {
+		t.Fatal("uncompilable dsl matcher expression accepted")
+	}
+	goodDSL := write("good-matcher-dsl.yaml", "id: gmd\ntype: http\nhttp:\n  paths: [\"/\"]\n  matchers:\n    - type: dsl\n      dsl: [\"status_code == 200\"]\n")
+	if _, err := ParseYAMLModule(goodDSL); err != nil {
+		t.Fatalf("valid dsl matcher rejected: %v", err)
+	}
+}
+
 func TestGetPart(t *testing.T) {
 	header := http.Header{"Server": []string{"nginx"}}
 	resp := fakeResponse(t, 200, header)

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -107,6 +107,10 @@ type Matcher struct {
 	Max *int `yaml:"max,omitempty"`
 	// CaseInsensitive folds word matching to lower-case when set (word matcher only).
 	CaseInsensitive bool `yaml:"case-insensitive,omitempty"`
+
+	// DSL holds one or more boolean expressions evaluated against the response
+	// (dsl matchers only). Compiled and validated at module load.
+	DSL []string `yaml:"dsl,omitempty"`
 }
 
 // MatchContext carries everything a matcher can evaluate against one response,


### PR DESCRIPTION
stacked on #379, so only the commits above it are this pr's.

modules can match on words, regex, status and size, but not on a relation between them, so anything like "200 and body contains x and it took under 2s" needs a new matcher type each time. this adds a dsl matcher over the nuclei expression language with a curated helper allowlist, compiled at load so bad syntax, a non-allowlisted function or an over-length expression fails before scan time rather than silently missing. host is bound to host[:port] from the parsed url, not the full url, so a nuclei-style host == "..." behaves the way someone pasting it expects.